### PR TITLE
change finishes, reset and respawns global variables to references

### DIFF
--- a/Grinding Stats.as
+++ b/Grinding Stats.as
@@ -63,9 +63,9 @@ bool setting_show_respawns_total = false;
 Timer session_time;
 Timer total_time;
 
-Respawns respawns;
-Finishes finishes;
-Resets resets;
+Respawns@ respawns = Respawns();
+Finishes@ finishes = Finishes();
+Resets@ resets = Resets();
 
 Files file;
 
@@ -113,10 +113,10 @@ void map_handler() {
             file = Files(map_id);
             session_time = Timer(0);
             total_time = Timer(file.get_time());
-            finishes = Finishes(file.get_finishes());
-            resets = Resets(file.get_resets());
+            @finishes = Finishes(file.get_finishes());
+            @resets = Resets(file.get_resets());
 #if TMNEXT
-            respawns = Respawns(file.get_respawns());
+            @respawns = Respawns(file.get_respawns());
 #endif
             timing = false;
             startnew(timer_handler);


### PR DESCRIPTION
To stop the coroutines for *finishes*, *resets* and *respawns* you set their member variable __running__ to *false*. But because the class instances get deconstructed (reassignment of the variables) before the coroutines are able to run again their member variable __running__ keep giving *true* even though it should be *false* and they run forever(?).

By only holding a reference to the instances they don't get deconstructed at reassignment but rather when the coroutine finishes and the garbage collector deconstructs it (because no one is holding a reference to it). That's at least how I understand it.

You can confirm it making a difference by opening Openplanet (F3) -> Developer -> Debug -> Profiler -> <Grinding Stats Plugin Name> and simply opening multiple maps e.g. first five of the campaign. On your version the *routines* time keeps growing.