### PR TITLE
:sparkles: Medal Achievement Time

### DIFF
--- a/Components/Finishes.as
+++ b/Components/Finishes.as
@@ -11,14 +11,14 @@ class Finishes : Component{
         string s = "";
         if (setting_show_finishes_session && 
         !(session == total && !setting_show_duplicates)) {
-            s += "\\$bbb" + session;
+            s += COLOR_GRAY + session;
         }
         if (setting_show_finishes_session && setting_show_finishes_total &&
          !(session == total && !setting_show_duplicates)) {
-            s += "\\$fff  /  ";
+            s += COLOR_WHITE + '  /  ';
         }
         if (setting_show_finishes_total) {
-            s += "\\$bbb" + total;
+            s += COLOR_GRAY + total;
         }
         return s;
     }

--- a/Components/Medals.as
+++ b/Components/Medals.as
@@ -1,0 +1,110 @@
+class Medals : Component {
+    Medal@ bronze = Medal(0);
+    Medal@ silver = Medal(0);
+    Medal@ gold = Medal(0);
+    Medal@ author = Medal(0);
+    
+    Medals() {}
+
+    Medals(
+        uint64 time_to_bronze,
+        uint64 time_to_silver,
+        uint64 time_to_gold,
+        uint64 time_to_author
+    ) {
+        bronze = Medal(time_to_bronze);
+        silver = Medal(time_to_silver);
+        gold = Medal(time_to_gold);
+        author = Medal(time_to_author);
+    }
+
+    void lock_earlier_medals() {
+        auto map_times = data.map_data.map_times;
+        if (map_times.personal_best > 0) {
+            if (
+                bronze.time_to_acq == 0
+                && map_times.personal_best < map_times.bronze
+            ) {
+                bronze.lock();
+            }
+            if (
+                silver.time_to_acq == 0
+                && map_times.personal_best < map_times.silver
+            ) {
+                silver.lock();
+            }
+            if (
+                gold.time_to_acq == 0
+                && map_times.personal_best < map_times.gold
+            ) {
+                gold.lock();
+            }
+            if (
+                author.time_to_acq == 0
+                && map_times.personal_best < map_times.author
+            ) {
+                author.lock();
+            }
+        }
+    }
+
+    void handler() override {
+#if TMNEXT
+        while (running) {
+            auto app = GetApp();
+            auto playground = app.CurrentPlayground;
+
+            if (playground is null || playground.GameTerminals.Length == 0) {
+                yield();
+                continue;
+            }
+
+            auto terminal = playground.GameTerminals[0];
+            auto gui_player = cast<CSmPlayer>(terminal.GUIPlayer);
+
+            if (gui_player is null) {
+                yield();
+                continue;
+            }
+
+            if (!handled && terminal.UISequence_Current == CGamePlaygroundUIConfig::EUISequence::Finish) {
+                handled = true;
+                
+                auto playgroundScript = cast<CSmArenaRulesMode>(app.PlaygroundScript);
+
+                if (playgroundScript is null) {
+                    // TODO: figure out how to get finish time when playing online
+                    yield();
+                    continue;
+                }
+
+                auto playerScriptAPI = cast<CSmScriptPlayer>(gui_player.ScriptAPI);
+                auto ghost = playgroundScript.Ghost_RetrieveFromPlayer(playerScriptAPI);
+
+                auto finishTime = ghost.Result.Time;
+                auto currTotalTime = data.timer.total;
+                auto mapTimes = data.map_data.map_times;
+
+                if (!bronze.is_locked() && bronze.time_to_acq == 0 && finishTime <= mapTimes.bronze) {
+                    bronze.time_to_acq = currTotalTime;
+                }
+                if (!silver.is_locked() && silver.time_to_acq == 0 && finishTime <= mapTimes.silver) {
+                    silver.time_to_acq = currTotalTime;
+                }
+                if (!gold.is_locked() && gold.time_to_acq == 0 && finishTime <= mapTimes.gold) {
+                    gold.time_to_acq = currTotalTime;
+                }
+                if (!author.is_locked() && author.time_to_acq == 0 && finishTime <= mapTimes.author) {
+                    author.time_to_acq = currTotalTime;
+                }
+
+                playgroundScript.DataFileMgr.Ghost_Release(ghost.Id);
+            } else if (handled && terminal.UISequence_Current != CGamePlaygroundUIConfig::EUISequence::Finish) {
+                handled = false;
+            }
+
+            yield();
+        }
+#endif
+    };
+}

--- a/Components/Resets.as
+++ b/Components/Resets.as
@@ -11,14 +11,14 @@ class Resets : Component {
         string s = "";
         if (setting_show_resets_session && 
         !(session == total && !setting_show_duplicates)) {
-            s += "\\$bbb" + session;
+            s += COLOR_GRAY + session;
         }
         if (setting_show_resets_session && setting_show_resets_total &&
          !(session == total && !setting_show_duplicates)) {
-            s += "\\$fff  /  ";
+            s += COLOR_WHITE + '  /  ';
         }
         if (setting_show_resets_total) {
-            s += "\\$bbb" + total;
+            s += COLOR_GRAY + total;
         }
         return s;
     }

--- a/Components/Respawns.as
+++ b/Components/Respawns.as
@@ -10,18 +10,50 @@ class Respawns : Component {
     }
 
     string toString() override {
-        if (!setting_show_duplicates && (current == session && current == total)) {
-            return "\\$bbb" + current;
+        // session / total display
+        if (!setting_show_respawns_current) {
+            if (
+                !setting_show_respawns_session
+                || (!setting_show_duplicates && session == total)
+            ) {
+                return COLOR_GRAY + total;
+            }
+            if (!setting_show_respawns_total) {
+                return COLOR_GRAY + session;
+            }
+            return COLOR_GRAY + session + COLOR_WHITE + "  /  " + COLOR_GRAY + total;
         }
+
+        // display one value only
+        if (
+            (!setting_show_respawns_session && !setting_show_respawns_total) // if only current enabled
+            || (!setting_show_respawns_session && !setting_show_duplicates && current == total) // session disabled and current and total are same
+            || (!setting_show_respawns_total && !setting_show_duplicates && current == session) // total disabled and current and session are same
+            || (!setting_show_duplicates && current == session && current == total) // all 3 are the same
+        ) {
+            return COLOR_GRAY + current;
+        }
+
+        // current / total display
+        if (!setting_show_respawns_session) {
+            return COLOR_GRAY + current + COLOR_WHITE + "  /  " + COLOR_GRAY + total;
+        }
+
+        // current / session display
+        if (!setting_show_respawns_total) {
+            return COLOR_GRAY + current + COLOR_WHITE + "  /  " + COLOR_GRAY + session;
+        }
+
+        // 2 out of 3 are the same (and not showing duplicates)
         if (!setting_show_duplicates && 
         (current != session && session == total) ||
         (current == session && session != total)) {
-            return "\\$bbb" + current + " \\$fff / " 
-              + "\\$bbb" + total;
+            return COLOR_GRAY + current + COLOR_WHITE + "  /  " + COLOR_GRAY + total;
         }
-        return "\\$bbb" + current + " \\$fff / " 
-              + "\\$bbb" + session + " \\$fff / "
-              + "\\$bbb" + total;
+
+        return COLOR_GRAY + current + COLOR_WHITE + "  /  " 
+              + COLOR_GRAY + session + COLOR_WHITE + "  /  "
+              + COLOR_GRAY + total;
 }
 
     void handler() override {

--- a/Components/Timer.as
+++ b/Components/Timer.as
@@ -121,7 +121,7 @@ class Timer : Component {
 namespace Timer {
     string to_string(uint64 time) {
         if (time == 0) return "--:--:--." + (setting_show_thousands ? "---":"--");
-        string str = Time::Format(time,true,true,setting_show_hour_if_0,false);
-        return setting_show_thousands ? str: str.SubStr(0, str.Length - 1);
+        string str = Time::Format(time, setting_show_fractions_of_second, true, setting_show_hour_if_0, false);
+        return (!setting_show_fractions_of_second || setting_show_thousands) ? str : str.SubStr(0, str.Length - 1);
     }
 }

--- a/Files/Data.as
+++ b/Files/Data.as
@@ -1,49 +1,49 @@
 class Data {
-    private string folder_location = IO::FromDataFolder("") + "Grinding Stats";
     string mapUid = "";
     string file = "";
+    MapData@ map_data = MapData();
 
     Finishes@ finishes = Finishes(0);
     Resets@ resets = Resets(0);
     Respawns@ respawns = Respawns(0);
     Timer@ timer = Timer(0);
+    Medals@ medals = Medals(0, 0, 0, 0);
     Files files;
 
     private bool cloud_save_failed = false;
+
     Data()  {
         startnew(CoroutineFunc(map_handler));
-        if (!IO::FolderExists(folder_location)) IO::CreateFolder(folder_location);
     }
-
-
     
     void map_handler() {
-        string mapId = "";
         auto app = GetApp();
         while (true) {
 #if TMNEXT
-        auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
-        mapId = (playground is null || playground.Map is null) ? "" : playground.Map.IdName;
+            auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
+            auto map = playground !is null ? playground.Map : null;
+            string mapId = (map is null) ? "" : map.IdName;
 #elif MP4
-        auto rootmap = app.RootMap;
-        mapId = (rootmap is null ) ? "" : rootmap.IdName;
+            auto rootmap = app.RootMap;
+            string mapId = (rootmap is null ) ? "" : rootmap.IdName;
 #elif TURBO
-        auto challenge = app.Challenge;
-        mapId = (challenge is null) ? "" : challenge.IdName;
+            auto challenge = app.Challenge;
+            string mapId = (challenge is null) ? "" : challenge.IdName;
 #endif
-        if (mapId != mapUid && app.Editor is null) { 
-            //the map has changed and we are not in the editor.
-            //the map has changed //we should save and then load the new map's data
-            timer.timing = false;
-            auto saving = startnew(CoroutineFunc(save));
-            while (saving.IsRunning()) yield();
-            mapUid = mapId;
-            file = folder_location + "/" + mapUid + '.json';
-            
-            startnew(CoroutineFunc(load));
-            
-        }
-        yield();
+            if (mapId != mapUid && app.Editor is null) { 
+                //the map has changed and we are not in the editor.
+                //the map has changed //we should save and then load the new map's data
+                timer.timing = false;
+                auto saving = startnew(CoroutineFunc(save));
+                while (saving.IsRunning()) yield();
+                mapUid = mapId;
+                map_data = MapData(mapId);
+                file = folder_location + "/" + mapUid + '.json';
+
+                startnew(CoroutineFunc(load));
+
+            }
+            yield();
         }
     }
 
@@ -51,12 +51,12 @@ class Data {
         save();
     }
 
-
     void start() {
         timer.start();
         finishes.start();
         resets.start();
         respawns.start();
+        medals.start();
     }
 
 
@@ -70,6 +70,12 @@ class Data {
             resets = Resets(files.resets);
             timer = Timer(files.time);
             respawns = Respawns(files.respawns);
+            medals = Medals(
+                files.time_to_bronze.time,
+                files.time_to_silver.time,
+                files.time_to_gold.time,
+                files.time_to_author.time
+            );
             
             start();
         }
@@ -84,6 +90,10 @@ class Data {
               files.finishes = finishes.total;
               files.resets = resets.total;
               files.respawns = respawns.total;
+              files.time_to_bronze.set_time_from_medal(medals.bronze);
+              files.time_to_silver.set_time_from_medal(medals.silver);
+              files.time_to_gold.set_time_from_medal(medals.gold);
+              files.time_to_author.set_time_from_medal(medals.author);
               files.write_file();
         }
     }

--- a/GrindingStats.as
+++ b/GrindingStats.as
@@ -4,72 +4,17 @@ enum displays {
     Always
 }
 
-[Setting name="Enabled" category="UI"]
-bool setting_enabled = true;
-
-[Setting name="Lock window location" category="UI"]
-bool setting_lock_window_location = false;
-
-[Setting name="Display setting" category="UI"]
-displays setting_display = displays::Always_except_when_interface_is_hidden;
-
-[Setting name="Show Duplicates" category="UI" description="will show both total and session time, finishes and resets if they are the same "]
-bool setting_show_duplicates = false;
-
-[Setting name="Show map name/author" category="UI"]
-bool setting_show_map_name = true;
-
-[Setting name="Show map name/author with color codes" category="UI"]
-bool setting_show_map_name_color = true;
-
-[Setting name="Show thousands" category="UI"]
-bool setting_show_thousands = false;
-
-[Setting name="Show Hour if 0" category="UI"]
-bool setting_show_hour_if_0 = false;
-
-[Setting name="Show Total time" category="Stats"]
-bool setting_show_total_time = true;
-
-[Setting name="Show Session time" category="Stats"]
-bool setting_show_session_time = true;
-
-[Setting name="Show Session finishes" category="Stats"]
-bool setting_show_finishes_session = true;
-[Setting name="Show Total finishes" category="Stats"]
-bool setting_show_finishes_total = true;
-
-[Setting name="Show Session resets" category="Stats"]
-bool setting_show_resets_session = true;
-[Setting name="Show Total resets" category="Stats"]
-bool setting_show_resets_total = true;
-
-[Setting name="Idle Detection Speed" category="Idle" description="The speed where the car will be considered idle after a set time. (this is not the speed that the car is going but the internal value of the speed)"]
-uint setting_idle_speed = 2;
-[Setting name="Idle Detection Delay" category="Idle" description="The amount of time before Idling will begin."]
-uint setting_idle_time = 5;
-
-[Setting name="Show Current Run's respawns" category="Stats"]
-bool setting_show_respawns_current = false;
-[Setting name="Show Session respawns" category="Stats"]
-bool setting_show_respawns_session = false;
-[Setting name="Show Total respawns" category="Stats"]
-bool setting_show_respawns_total = false;
-
-[Setting name="Show debug information" category="Debug"]
-bool setting_show_debug = false;
-
-
 Data data;
 Recap recap;
 
 bool recap_enabled = false;
-
+string folder_location = IO::FromDataFolder('') + 'Grinding Stats';
 
 void Main()
-{    
+{
 #if DEPENDENCY_NADEOSERVICES
     NadeoServices::AddAudience("NadeoLiveServices");
 #endif
     if (setting_recap_show_menu && !recap.started) recap.start(); 
+    if (!IO::FolderExists(folder_location)) IO::CreateFolder(folder_location);
 }

--- a/Helpers/BoolRef.as
+++ b/Helpers/BoolRef.as
@@ -1,0 +1,6 @@
+class BoolRef {
+    bool value = false;
+
+    BoolRef() {}
+    BoolRef(bool _value) { value = _value; }
+}

--- a/Helpers/Colors.as
+++ b/Helpers/Colors.as
@@ -1,0 +1,10 @@
+const string COLOR_WHITE = '\\$fff';
+const string COLOR_LIGHT_GRAY = '\\$ddd';
+const string COLOR_GRAY = '\\$bbb';
+const string COLOR_DARK_GRAY = '\\$888';
+
+const string COLOR_GREEN = '\\$6d0';
+const string COLOR_BRIGHT_GREEN = '\\$6f0';
+
+const string COLOR_ORANGE = '\\$f60';
+const string COLOR_BRIGHT_ORANGE = '\\$f80';

--- a/Helpers/Colors.as
+++ b/Helpers/Colors.as
@@ -4,7 +4,7 @@ const string COLOR_GRAY = '\\$bbb';
 const string COLOR_DARK_GRAY = '\\$888';
 
 const string COLOR_GREEN = '\\$6d0';
-const string COLOR_BRIGHT_GREEN = '\\$6f0';
+const string COLOR_LIGHT_GREEN = '\\$6f0';
 
 const string COLOR_ORANGE = '\\$f60';
-const string COLOR_BRIGHT_ORANGE = '\\$f80';
+const string COLOR_LIGHT_ORANGE = '\\$f80';

--- a/Helpers/NadeoServicesHelpers.as
+++ b/Helpers/NadeoServicesHelpers.as
@@ -1,0 +1,7 @@
+Json::Value FetchEndpoint(const string &in route) {
+    while (!NadeoServices::IsAuthenticated("NadeoLiveServices")) yield();
+    auto req = NadeoServices::Get("NadeoLiveServices", route);
+    req.Start();
+    while(!req.Finished()) yield();
+    return Json::Parse(req.String());
+}

--- a/Helpers/NullableUint64.as
+++ b/Helpers/NullableUint64.as
@@ -1,0 +1,32 @@
+class NullableUint64 {
+    private bool _has_value = false;
+    private uint64 _value;
+
+    NullableUint64() {}
+
+    NullableUint64(uint64 value) {
+        _value = value;
+        _has_value = true;
+    }
+
+    bool has_value {
+        get const {
+            return _has_value;
+        }
+    }
+
+    uint64 value {
+        get const {
+            if (!_has_value) {
+                throw("Nullable uint64 has no value");
+            }
+            return _value;
+        }
+    }
+
+    uint64 value_or_default {
+        get const {
+            return _has_value ? _value : 0;
+        }
+    }
+}

--- a/Models/FileMedalTime.as
+++ b/Models/FileMedalTime.as
@@ -79,8 +79,8 @@ class FileMedalTime {
 
         return COLOR_GREEN + (
             medal_time_type == MedalTimeType::MedalAchievementTimeUnknown
-            ? '+'
-            : Medal::to_string(_time.value)
+                ? '+'
+                : Medal::to_string(_time.value)
         );
     }
 }

--- a/Models/FileMedalTime.as
+++ b/Models/FileMedalTime.as
@@ -1,0 +1,86 @@
+enum MedalTimeType {
+    KeyNotExists,
+    MedalAchievementTimeUnknown,
+    Unachieved,
+    Achieved
+}
+
+class FileMedalTime {
+
+    private BoolRef@ _is_unknown = BoolRef();
+    private NullableUint64@ _time = NullableUint64();
+
+    FileMedalTime() {}
+
+    uint64 time {
+        get const {
+            return _time.value_or_default;
+        }
+    }
+
+    int64 sort_val {
+        get const {
+            if (medal_time_type == MedalTimeType::KeyNotExists)
+                return -3;
+            if (medal_time_type == MedalTimeType::Unachieved)
+                return -2;
+            if (medal_time_type == MedalTimeType::MedalAchievementTimeUnknown)
+                return -1;
+            return int64(this.time);
+        }
+    }
+
+    MedalTimeType medal_time_type {
+        get const {
+            if (_is_unknown.value) {
+                return MedalTimeType::MedalAchievementTimeUnknown;
+            }
+            if (!_time.has_value) {
+                return MedalTimeType::KeyNotExists;
+            }
+            if (_time.value == 0) {
+                return MedalTimeType::Unachieved;
+            }
+            return MedalTimeType::Achieved;
+        }
+    }
+
+    void set_time_from_medal(Medal medal) {
+        if (medal.is_locked()) {
+            _is_unknown.value = true;
+            return;
+        }
+        _time = medal.time_to_acq;
+    }
+
+    void decode_time(const string &in json_value) {
+        if (json_value == '')
+            return;
+
+        if (json_value == 'unknown') {
+            _is_unknown.value = true;
+            return;
+        }
+        _time = NullableUint64(Text::ParseUInt64(json_value));
+    }
+
+    string encode_time() {
+        if (_is_unknown.value) {
+            return 'unknown';
+        }
+        return Text::Format("%11d", this.time);
+    }
+    
+    string to_string() {
+        if (medal_time_type == MedalTimeType::KeyNotExists)
+            return '';
+        if (medal_time_type == MedalTimeType::Unachieved)
+            return COLOR_ORANGE + '-';
+
+        return COLOR_GREEN + (
+            medal_time_type == MedalTimeType::MedalAchievementTimeUnknown
+            ? '+'
+            : Medal::to_string(_time.value)
+        );
+    }
+}

--- a/Models/MapData.as
+++ b/Models/MapData.as
@@ -40,8 +40,8 @@ class MapData {
         if (local_pb > 0) {
             map_times.personal_best = local_pb;
             startnew(CoroutineFunc(data.medals.lock_earlier_medals));
-            load_online_pb();
         }
+        load_online_pb();
     }
 
     private void load_online_pb() {

--- a/Models/MapData.as
+++ b/Models/MapData.as
@@ -1,0 +1,73 @@
+class MapData {
+    string mapUid = '';
+    MapTimes@ map_times = MapTimes();
+    
+    MapData() {}
+
+    MapData(string _mapUid) {
+        mapUid = _mapUid;
+#if TMNEXT
+        if (_mapUid != '') {
+            load_medal_times();
+            startnew(CoroutineFunc(load_personal_best));
+        }
+#endif
+    }
+
+    private void load_medal_times() {
+        auto app = GetApp();
+        auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
+        auto map = playground !is null ? playground.Map : null;
+
+        if (map !is null) {
+            map_times.bronze = map.TMObjective_BronzeTime;
+            map_times.silver = map.TMObjective_SilverTime;
+            map_times.gold = map.TMObjective_GoldTime;
+            map_times.author = map.TMObjective_AuthorTime;
+        }
+    }
+
+    private void load_personal_best() {
+        auto app = cast<CTrackMania>(GetApp());
+        auto network = cast<CTrackManiaNetwork>(app.Network);
+        auto scoreMgr = network.ClientManiaAppPlayground.ScoreMgr;
+
+        auto userMgr = network.ClientManiaAppPlayground.UserMgr;
+        auto userId = userMgr.Users.Length > 0 ? userMgr.Users[0].Id : uint(-1);
+
+        uint local_pb = scoreMgr.Map_GetRecord_v2(userId, mapUid, "PersonalBest", "", "TimeAttack", "");
+
+        if (local_pb > 0) {
+            map_times.personal_best = local_pb;
+            startnew(CoroutineFunc(data.medals.lock_earlier_medals));
+            load_online_pb();
+        }
+    }
+
+    private void load_online_pb() {
+#if DEPENDENCY_NADEOSERVICES
+        auto info = FetchEndpoint(NadeoServices::BaseURL() + "/api/token/leaderboard/group/Personal_Best/map/" + mapUid + "/surround/0/0?onlyWorld=true");
+        if (info.GetType() == Json::Type::Null) {
+            return;
+        }
+        auto tops = info["tops"];
+        if (tops.GetType() != Json::Type::Array) {
+            return;
+        }
+        auto top = tops[0]["top"];
+        if (top.Length == 0) {
+            return;
+        }
+        uint score = top[0]["score"];
+        if (score == 0) {
+            return;
+        }
+        map_times.personal_best = (
+            map_times.personal_best > 0 && map_times.personal_best < score
+                ? map_times.personal_best
+                : score
+        );
+        startnew(CoroutineFunc(data.medals.lock_earlier_medals));
+#endif
+    }
+}

--- a/Models/MapTimes.as
+++ b/Models/MapTimes.as
@@ -1,0 +1,9 @@
+class MapTimes {
+    uint bronze = 0;
+    uint silver = 0;
+    uint gold = 0;
+    uint author = 0;
+    uint personal_best = 0;
+
+    MapTimes() {}
+}

--- a/Models/Medal.as
+++ b/Models/Medal.as
@@ -1,0 +1,32 @@
+class Medal {
+    private bool _is_locked = false;
+    uint64 time_to_acq = 0;
+
+    Medal() {}
+
+    Medal(uint64 _time_to_acq) {
+        time_to_acq = _time_to_acq;
+    }
+
+    string toString() {
+        if (_is_locked) {
+            return COLOR_GRAY + '+';
+        }
+        return COLOR_GRAY + Medal::to_string(time_to_acq);
+    }
+
+    void lock() {
+        _is_locked = true;
+    }
+
+    bool is_locked() {
+        return _is_locked;
+    }
+}
+
+namespace Medal {
+    string to_string(uint64 time) {
+        if (time == 0) return '-';
+        return Time::Format(time, false, true, setting_show_hour_if_0, false);
+    }
+}

--- a/Models/MedalTotals.as
+++ b/Models/MedalTotals.as
@@ -1,0 +1,149 @@
+class MedalTotals {
+    private uint _item_count = 0;
+
+    private uint _bronze_medal_count = 0;
+    private uint _silver_medal_count = 0;
+    private uint _gold_medal_count = 0;
+    private uint _author_medal_count = 0;
+
+    private uint _bronze_medal_time_unknown_count = 0;
+    private uint _silver_medal_time_unknown_count = 0;
+    private uint _gold_medal_time_unknown_count = 0;
+    private uint _author_medal_time_unknown_count = 0;
+
+    private uint _unread_file_count = 0;
+
+    private uint _total_time_to_bronze = 0;
+    private uint _total_time_to_silver = 0;
+    private uint _total_time_to_gold = 0;
+    private uint _total_time_to_author = 0;
+
+    void count_totals(array<RecapElement@> elements) {
+        _item_count = elements.Length;
+
+        _bronze_medal_count = 0;
+        _silver_medal_count = 0;
+        _gold_medal_count = 0;
+        _author_medal_count = 0;
+
+        _bronze_medal_time_unknown_count = 0;
+        _silver_medal_time_unknown_count = 0;
+        _gold_medal_time_unknown_count = 0;
+        _author_medal_time_unknown_count = 0;
+
+        _unread_file_count = 0;
+
+        _total_time_to_bronze = 0;
+        _total_time_to_silver = 0;
+        _total_time_to_gold = 0;
+        _total_time_to_author = 0;
+        
+        for (uint i = 0; i < elements.Length; i++) {
+            if (elements[i].time_to_bronze.medal_time_type == MedalTimeType::KeyNotExists) {
+                _unread_file_count++;
+                continue;
+            }
+
+            _total_time_to_bronze += elements[i].time_to_bronze.time;
+            _total_time_to_silver += elements[i].time_to_silver.time;
+            _total_time_to_gold += elements[i].time_to_gold.time;
+            _total_time_to_author += elements[i].time_to_author.time;
+
+            if (elements[i].time_to_bronze.medal_time_type == MedalTimeType::Achieved) {
+                _bronze_medal_count++;
+            } else if (elements[i].time_to_bronze.medal_time_type == MedalTimeType::MedalAchievementTimeUnknown) {
+                _bronze_medal_time_unknown_count++;
+            }
+                
+            if (elements[i].time_to_silver.medal_time_type == MedalTimeType::Achieved) {
+                _silver_medal_count++;
+            } else if (elements[i].time_to_silver.medal_time_type == MedalTimeType::MedalAchievementTimeUnknown) {
+                _silver_medal_time_unknown_count++;
+            }
+
+            if (elements[i].time_to_gold.medal_time_type == MedalTimeType::Achieved) {
+                _gold_medal_count++;
+            } else if (elements[i].time_to_gold.medal_time_type == MedalTimeType::MedalAchievementTimeUnknown) {
+                _gold_medal_time_unknown_count++;
+            }
+
+            if (elements[i].time_to_author.medal_time_type == MedalTimeType::Achieved) {
+                _author_medal_count++;
+            } else if (elements[i].time_to_author.medal_time_type == MedalTimeType::MedalAchievementTimeUnknown) {
+                _author_medal_time_unknown_count++;
+            }
+        }
+    }
+
+    private string acq_percentage_str(uint medal_count) {
+        if (_item_count == 0 || _unread_file_count != 0) {
+            return '';
+        }
+        auto remaining_items = _item_count - medal_count;
+
+        if (remaining_items == 0) {
+            return COLOR_BRIGHT_GREEN + ' (100%)';
+        } else {
+            auto acq_perc = Math::Round((float(medal_count) / _item_count) * 100);
+            return COLOR_BRIGHT_ORANGE + ' (' + medal_count + '/' + _item_count + ' - ' + acq_perc + '%)';
+        }
+    }
+
+    private string totals_str(
+        uint medal_count, uint unknown_medal_count, uint total_time
+    ) {
+        auto all_medals_acq = _item_count == (medal_count + unknown_medal_count);
+        auto color_prefix = all_medals_acq ? COLOR_BRIGHT_GREEN : '';
+
+        if (all_medals_acq && total_time == 0) {
+            return color_prefix + '+';
+        }
+        auto unknown_prefix = (unknown_medal_count > 0 && total_time > 0) ? '> ' : '';
+
+        return color_prefix + unknown_prefix + Medal::to_string(total_time);
+    }
+
+    string bronze_perc {
+        get const {
+            return acq_percentage_str(_bronze_medal_count + _bronze_medal_time_unknown_count);
+        }
+    }
+    string silver_perc {
+        get const {
+            return acq_percentage_str(_silver_medal_count + _silver_medal_time_unknown_count);
+        }
+    }
+    string gold_perc {
+        get const {
+            return acq_percentage_str(_gold_medal_count + _gold_medal_time_unknown_count);
+        }
+    }
+    string author_perc {
+        get const {
+            return acq_percentage_str(_author_medal_count + _author_medal_time_unknown_count);
+        }
+    }
+    
+    string bronze_totals {
+        get const {
+            return totals_str(_bronze_medal_count, _bronze_medal_time_unknown_count, _total_time_to_bronze);
+        }
+    }
+    string silver_totals {
+        get const {
+            return totals_str(_silver_medal_count, _silver_medal_time_unknown_count, _total_time_to_silver);
+        }
+    }
+    string gold_totals {
+        get const {
+            return totals_str(_gold_medal_count, _gold_medal_time_unknown_count, _total_time_to_gold);
+        }
+    }
+    string author_totals {
+        get const {
+            return totals_str(_author_medal_count, _author_medal_time_unknown_count, _total_time_to_author);
+        }
+    }
+
+    MedalTotals() {}
+}

--- a/Models/MedalTotals.as
+++ b/Models/MedalTotals.as
@@ -82,10 +82,10 @@ class MedalTotals {
         auto remaining_items = _item_count - medal_count;
 
         if (remaining_items == 0) {
-            return COLOR_BRIGHT_GREEN + ' (100%)';
+            return COLOR_LIGHT_GREEN + ' (100%)';
         } else {
             auto acq_perc = Math::Round((float(medal_count) / _item_count) * 100);
-            return COLOR_BRIGHT_ORANGE + ' (' + medal_count + '/' + _item_count + ' - ' + acq_perc + '%)';
+            return COLOR_LIGHT_ORANGE + ' (' + medal_count + '/' + _item_count + ' - ' + acq_perc + '%)';
         }
     }
 
@@ -93,7 +93,7 @@ class MedalTotals {
         uint medal_count, uint unknown_medal_count, uint total_time
     ) {
         auto all_medals_acq = _item_count == (medal_count + unknown_medal_count);
-        auto color_prefix = all_medals_acq ? COLOR_BRIGHT_GREEN : '';
+        auto color_prefix = all_medals_acq ? COLOR_LIGHT_GREEN : '';
 
         if (all_medals_acq && total_time == 0) {
             return color_prefix + '+';

--- a/Recap/Recap.as
+++ b/Recap/Recap.as
@@ -23,6 +23,7 @@ class Recap {
     uint total_finishes = 0;
     uint total_resets = 0;
     uint total_respawns = 0;
+    MedalTotals@ medal_totals = MedalTotals();
 
     private void count_total_time() {
         total_time = 0;
@@ -50,8 +51,20 @@ class Recap {
         for (uint i = 0; i < filtered_elements.Length; i++) {
             total_respawns += filtered_elements[i].respawns;
         }
-        
     }
+
+    private void count_totals_for_medals() {
+        medal_totals.count_totals(filtered_elements);
+    }
+
+    private void count_totals() {
+        count_total_finishes();
+        count_total_resets();
+        count_total_respawns();
+        count_total_time();
+        count_totals_for_medals();
+    }
+
     Recap() {
         elements = array<RecapElement@>();
         dirty = false;
@@ -78,8 +91,19 @@ class Recap {
                     case 1: filtered_elements.Sort(function(a,b) {return a.time_uint < b.time_uint;});break;
                     case 2: filtered_elements.Sort(function(a,b) {return a.finishes < b.finishes;});break;
                     case 3: filtered_elements.Sort(function(a,b) {return a.resets < b.resets;});break;
+#if TMNEXT
+                    case 4: filtered_elements.Sort(function(a,b) {return a.respawns < b.respawns;});break;
+                    case 5: filtered_elements.Sort(function(a,b) {return a.time_to_bronze.sort_val < b.time_to_bronze.sort_val;});break;
+                    case 6: filtered_elements.Sort(function(a,b) {return a.time_to_silver.sort_val < b.time_to_silver.sort_val;});break;
+                    case 7: filtered_elements.Sort(function(a,b) {return a.time_to_gold.sort_val < b.time_to_gold.sort_val;});break;
+                    case 8: filtered_elements.Sort(function(a,b) {return a.time_to_author.sort_val < b.time_to_author.sort_val;});break;
+                    case 9: filtered_elements.Sort(function(a,b) {return a.modified_time < b.modified_time;});break;
+#elif MP4
+                    case 4: filtered_elements.Sort(function(a,b) {return a.titlepack < b.titlepack;});break;
+                    case 5: filtered_elements.Sort(function(a,b) {return a.modified_time < b.modified_time;});break;
+#else
                     case 4: filtered_elements.Sort(function(a,b) {return a.modified_time < b.modified_time;});break;
-                    case 5: filtered_elements.Sort(function(a,b) {return a.respawns < b.respawns;});break;
+#endif
                 }
             }
             else if (spec.SortDirection == UI::SortDirection::Descending) {
@@ -88,9 +112,19 @@ class Recap {
                     case 1: filtered_elements.Sort(function(a,b) {return a.time_uint > b.time_uint;});break;
                     case 2: filtered_elements.Sort(function(a,b) {return a.finishes > b.finishes;});break;
                     case 3: filtered_elements.Sort(function(a,b) {return a.resets > b.resets;});break;
+#if TMNEXT
+                    case 4: filtered_elements.Sort(function(a,b) {return a.respawns > b.respawns;});break;
+                    case 5: filtered_elements.Sort(function(a,b) {return a.time_to_bronze.sort_val > b.time_to_bronze.sort_val;});break;
+                    case 6: filtered_elements.Sort(function(a,b) {return a.time_to_silver.sort_val > b.time_to_silver.sort_val;});break;
+                    case 7: filtered_elements.Sort(function(a,b) {return a.time_to_gold.sort_val > b.time_to_gold.sort_val;});break;
+                    case 8: filtered_elements.Sort(function(a,b) {return a.time_to_author.sort_val > b.time_to_author.sort_val;});break;
+                    case 9: filtered_elements.Sort(function(a,b) {return a.modified_time > b.modified_time;});break;
+#elif MP4
+                    case 4: filtered_elements.Sort(function(a,b) {return a.titlepack > b.titlepack;});break;
+                    case 5: filtered_elements.Sort(function(a,b) {return a.modified_time > b.modified_time;});break;
+#else
                     case 4: filtered_elements.Sort(function(a,b) {return a.modified_time > b.modified_time;});break;
-                    case 5: filtered_elements.Sort(function(a,b) {return a.respawns > b.respawns;});break;
-                   
+#endif
                 }
             }
             yield();
@@ -106,19 +140,16 @@ class Recap {
         current_campaign = array<string>();
         totds = array<string>();
         await(startnew(CoroutineFunc(load_files)));
-        count_total_finishes();
-        count_total_resets();
-        count_total_respawns();
-        count_total_time();
+        count_totals();
         filter_elements();
     }
     
     private void load_files() {
-        auto files = IO::IndexFolder(IO::FromDataFolder("")+"Grinding Stats",true);
+        auto files = IO::IndexFolder(folder_location, true);
         if (elements.Length != files.Length) {
             elements = array<RecapElement@>();
         } else {return;}
-        uint path_length = (IO::FromDataFolder('') + "Grinding Stats/").Length;
+        uint path_length = (folder_location + '/').Length;
         //loading files will be done in batches of 100
         uint batches = uint(Math::Ceil(files.Length / 100.0));
         for (uint i = 0; i < batches; i++) {
@@ -131,10 +162,7 @@ class Recap {
             yield();
         }
         dirty = true;
-        count_total_finishes();
-        count_total_resets();
-        count_total_respawns();
-        count_total_time();
+        count_totals();
         recap.filter_elements();
     }
     void filter_elements() {
@@ -159,10 +187,7 @@ class Recap {
         }
         this.dirty = true;
 
-        count_total_finishes();
-        count_total_resets();
-        count_total_respawns();
-        count_total_time();
+        count_totals();
     }
     private void filter_all(bool uploaded) {
         for (uint i = 0; i < elements.Length; i++) {

--- a/Recap/RecapElement.as
+++ b/Recap/RecapElement.as
@@ -8,15 +8,18 @@ class RecapElement {
     uint64 finishes;
     uint64 resets;
     uint64 respawns;
+
+    FileMedalTime time_to_bronze;
+    FileMedalTime time_to_silver;
+    FileMedalTime time_to_gold;
+    FileMedalTime time_to_author;
+
     int64 modified_time;
 #if MP4
     string titlepack;
 #endif
 
-
-    RecapElement() {
-        
-    }
+    RecapElement() {}
 
     RecapElement(const string &in id) {
 #if MP4
@@ -32,6 +35,12 @@ class RecapElement {
         finishes = file.get_finishes();
         resets = file.get_resets();
         respawns = file.get_respawns();
+
+        time_to_bronze = file.get_time_to_bronze();
+        time_to_silver = file.get_time_to_silver();
+        time_to_gold = file.get_time_to_gold();
+        time_to_author = file.get_time_to_author();
+
         modified_time =  file.get_modified_time();
         startnew(CoroutineFunc(get_name_from_api));
         

--- a/Recap/RecapFiles.as
+++ b/Recap/RecapFiles.as
@@ -16,7 +16,7 @@ class RecapFiles : Files {
         return;
     }
 
-        int64 get_modified_time() {
+    int64 get_modified_time() {
         return IO::FileModifiedTime(json_file);
     }
 }

--- a/Recap/RecapUI.as
+++ b/Recap/RecapUI.as
@@ -58,6 +58,7 @@ string recap_filter_string(recap_filter filter) {
 
 recap_filter current_recap = recap_filter::all;
 void RenderRecap() {
+    UI::PushStyleVar(UI::StyleVar::Alpha, float(1.022));
     if(UI::Begin("Grinding Stats Recap",setting_recap_show_menu,UI::WindowFlags::NoCollapse | UI::WindowFlags::MenuBar)) {
         //menu bar
         if (UI::BeginMenuBar()) {
@@ -92,7 +93,9 @@ void RenderRecap() {
         }
 #if TURBO
 uint columns = 5;
-#elif MP4||TMNEXT
+#elif TMNEXT
+uint columns = 10;
+#elif MP4
 uint columns = 6;
 #endif
         if (UI::BeginTable("Items",columns,UI::TableFlags::Sortable | UI::TableFlags::Resizable | UI::TableFlags::ScrollY)) {
@@ -103,13 +106,32 @@ uint columns = 6;
                                          UI::TableColumnFlags::PreferSortDescending | UI::TableColumnFlags::NoHide,150);
             UI::TableSetupColumn("Finishes",UI::TableColumnFlags::WidthFixed,100);
             UI::TableSetupColumn("Resets",UI::TableColumnFlags::WidthFixed,100);
-            UI::TableSetupColumn("Last Played", UI::TableColumnFlags::WidthFixed,100);
 #if TMNEXT
             UI::TableSetupColumn("Respawns",UI::TableColumnFlags::WidthFixed,100);
+            UI::TableSetupColumn(
+                "Bronze" + recap.medal_totals.bronze_perc,
+                UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::PreferSortDescending,
+                150
+            );
+            UI::TableSetupColumn(
+                "Silver" + recap.medal_totals.silver_perc,
+                UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::PreferSortDescending,
+                150
+            );
+            UI::TableSetupColumn(
+                "Gold" + recap.medal_totals.gold_perc,
+                UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::PreferSortDescending,
+                150
+            );
+            UI::TableSetupColumn(
+                "Author" + recap.medal_totals.author_perc,
+                UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::PreferSortDescending,
+                150
+            );
 #elif MP4
             UI::TableSetupColumn("Title pack",UI::TableColumnFlags::WidthFixed|UI::TableColumnFlags::NoResize,100);
 #endif
-            
+            UI::TableSetupColumn("Last Played", UI::TableColumnFlags::WidthFixed, 100);
             UI::TableHeadersRow();
 
             //sorting
@@ -126,6 +148,10 @@ uint columns = 6;
                         string finishes;
                         string resets;
                         string respawns;
+                        string time_to_bronze;
+                        string time_to_silver;
+                        string time_to_gold;
+                        string time_to_author;
                         string stripped_name;
                         string time_modified;
 #if MP4
@@ -140,6 +166,10 @@ uint columns = 6;
                         finishes = "" + element.finishes;
                         resets = "" + element.resets;
                         respawns = "" + element.respawns;
+                        time_to_bronze = element.time_to_bronze.to_string();
+                        time_to_silver = element.time_to_silver.to_string();
+                        time_to_gold = element.time_to_gold.to_string();
+                        time_to_author = element.time_to_author.to_string();
                         time_modified = Time::FormatString("%F %r",element.modified_time);
 #if MP4
                         titlepack = element.titlepack;
@@ -152,6 +182,10 @@ uint columns = 6;
                         finishes = "" + recap.total_finishes;
                         resets = "" + recap.total_resets;
                         respawns = "" + recap.total_respawns;
+                        time_to_bronze = recap.medal_totals.bronze_totals;
+                        time_to_silver = recap.medal_totals.silver_totals;
+                        time_to_gold = recap.medal_totals.gold_totals;
+                        time_to_author = recap.medal_totals.author_totals;
                         time_modified = "--:--:--";
                     }
                         UI::TableNextRow();
@@ -169,22 +203,35 @@ uint columns = 6;
                         UI::Text(finishes);
                         UI::TableSetColumnIndex(3);
                         UI::Text(resets);
+#if TMNEXT
+                        UI::TableSetColumnIndex(4);
+                        UI::Text(respawns);
+                        UI::TableSetColumnIndex(5);
+                        UI::Text(time_to_bronze);
+                        UI::TableSetColumnIndex(6);
+                        UI::Text(time_to_silver);
+                        UI::TableSetColumnIndex(7);
+                        UI::Text(time_to_gold);
+                        UI::TableSetColumnIndex(8);
+                        UI::Text(time_to_author);
+                        UI::TableSetColumnIndex(9);
+                        UI::Text(time_modified);
+#elif MP4
+                        UI::TableSetColumnIndex(4);
+                        UI::Text(titlepack);
+                        UI::TableSetColumnIndex(5);
+                        UI::Text(time_modified);
+#else
                         UI::TableSetColumnIndex(4);
                         UI::Text(time_modified);
-#if TMNEXT
-                        UI::TableSetColumnIndex(5);
-                        UI::Text(respawns);
-#elif MP4
-                        UI::TableSetColumnIndex(5);
-                        UI::Text(titlepack);
 #endif
-                        
                 }
             }
         UI::EndTable();
         }
     }
     UI::End();
+    UI::PopStyleVar();
 }
 
 void add_selectable(recap_filter filter) {

--- a/Rendering.as
+++ b/Rendering.as
@@ -13,10 +13,10 @@ void render_stats() {
                 UI::BeginTable("header",1,UI::TableFlags::SizingFixedFit);
                     UI::TableNextRow();
                     UI::TableNextColumn();
-                    UI::Text("\\$ddd" + format_string(map_info.Name));
+                    UI::Text(COLOR_LIGHT_GRAY + format_string(map_info.Name));
                     UI::TableNextRow();
                     UI::TableNextColumn();
-                    UI::Text("\\$888" + format_string(map_info.AuthorNickName));
+                    UI::Text(COLOR_DARK_GRAY + format_string(map_info.AuthorNickName));
                 UI::EndTable();
             }
             UI::BeginTable("table",2,UI::TableFlags::SizingFixedFit);
@@ -26,28 +26,28 @@ void render_stats() {
                    (data.timer.same && setting_show_session_time && setting_show_duplicates))) {
                 UI::TableNextRow();
                 UI::TableNextColumn();
-                UI::Text("\\$ddd" + (data.timer.isRunning() ? Icons::ClockO : Icons::PauseCircleO) + " Total Time");
+                UI::Text(COLOR_LIGHT_GRAY + (data.timer.isRunning() ? Icons::ClockO : Icons::PauseCircleO) + " Total Time");
                 UI::TableNextColumn();
-                UI::Text("\\$bbb" + Timer::to_string(data.timer.total));
+                UI::Text(COLOR_GRAY + Timer::to_string(data.timer.total));
             }
             if (setting_show_session_time) {
                 UI::TableNextRow();
                 UI::TableNextColumn();
-                UI::Text("\\$ddd" + (data.timer.isRunning() ? Icons::PlayCircleO : Icons::PauseCircleO) + " Session Time");
+                UI::Text(COLOR_LIGHT_GRAY + (data.timer.isRunning() ? Icons::PlayCircleO : Icons::PauseCircleO) + " Session Time");
                 UI::TableNextColumn();
-                UI::Text("\\$bbb" + Timer::to_string(data.timer.session));
+                UI::Text(COLOR_GRAY + Timer::to_string(data.timer.session));
             }
             if (setting_show_finishes_session || setting_show_finishes_total) {
                 UI::TableNextRow();
                 UI::TableNextColumn();
-                UI::Text("\\$ddd" + Icons::Flag + " Finishes");
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Flag + " Finishes");
                 UI::TableNextColumn();
-                UI::Text("\\$bbb" + data.finishes.toString());
+                UI::Text(COLOR_GRAY + data.finishes.toString());
             }
             if (setting_show_resets_session || setting_show_resets_total) {
                 UI::TableNextRow();
                 UI::TableNextColumn();
-                UI::Text("\\$ddd" + Icons::Repeat + " Resets");
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Repeat + " Resets");
                 UI::TableNextColumn();
                 UI::Text(data.resets.toString());
             }
@@ -55,9 +55,37 @@ void render_stats() {
             if (setting_show_respawns_current || setting_show_respawns_total || setting_show_respawns_session) {
                 UI::TableNextRow();
                 UI::TableNextColumn();
-                UI::Text("\\$ddd" + Icons::Refresh + " Respawns");
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Refresh + " Respawns");
                 UI::TableNextColumn();
                 UI::Text(data.respawns.toString());
+            }
+            if (setting_show_time_to_bronze) {
+                UI::TableNextRow();
+                UI::TableNextColumn();
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Kenney::StarO + " Bronze");
+                UI::TableNextColumn();
+                UI::Text(data.medals.bronze.toString());
+            }
+            if (setting_show_time_to_silver) {
+                UI::TableNextRow();
+                UI::TableNextColumn();
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Kenney::StarHalfO + " Silver");
+                UI::TableNextColumn();
+                UI::Text(data.medals.silver.toString());
+            }
+            if (setting_show_time_to_gold) {
+                UI::TableNextRow();
+                UI::TableNextColumn();
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Kenney::Star + " Gold");
+                UI::TableNextColumn();
+                UI::Text(data.medals.gold.toString());
+            }
+            if (setting_show_time_to_author) {
+                UI::TableNextRow();
+                UI::TableNextColumn();
+                UI::Text(COLOR_LIGHT_GRAY + Icons::Kenney::BadgeAlt + " Author");
+                UI::TableNextColumn();
+                UI::Text(data.medals.author.toString());
             }
 #endif
             UI::EndTable();

--- a/Settings.as
+++ b/Settings.as
@@ -1,0 +1,75 @@
+[Setting name="Enabled" category="UI"]
+bool setting_enabled = true;
+
+[Setting name="Lock window location" category="UI"]
+bool setting_lock_window_location = false;
+
+[Setting name="Display setting" category="UI"]
+displays setting_display = displays::Always_except_when_interface_is_hidden;
+
+[Setting name="Show Duplicates" category="UI" description="will show both total and session time, finishes and resets if they are the same "]
+bool setting_show_duplicates = false;
+
+[Setting name="Show map name/author" category="UI"]
+bool setting_show_map_name = true;
+[Setting name="Show map name/author with color codes" category="UI"]
+bool setting_show_map_name_color = true;
+
+[Setting name="Show fractions of second" category="UI"]
+bool setting_show_fractions_of_second = true;
+[Setting name="Show thousands" category="UI" description="If show fractions of second is enabled, toggles showing of the thousandth digit"]
+bool setting_show_thousands = false;
+
+[Setting name="Show Hour if 0" category="UI"]
+bool setting_show_hour_if_0 = false;
+
+[Setting name="Show Total time" category="Stats"]
+bool setting_show_total_time = true;
+[Setting name="Show Session time" category="Stats"]
+bool setting_show_session_time = true;
+
+[Setting name="Show Session finishes" category="Stats"]
+bool setting_show_finishes_session = true;
+[Setting name="Show Total finishes" category="Stats"]
+bool setting_show_finishes_total = true;
+
+[Setting name="Show Session resets" category="Stats"]
+bool setting_show_resets_session = true;
+[Setting name="Show Total resets" category="Stats"]
+bool setting_show_resets_total = true;
+
+#if TMNEXT
+[Setting name="Show Current Run's respawns" category="Stats"]
+bool setting_show_respawns_current = false;
+[Setting name="Show Session respawns" category="Stats"]
+bool setting_show_respawns_session = false;
+[Setting name="Show Total respawns" category="Stats"]
+bool setting_show_respawns_total = false;
+
+[Setting name="Show Time To Achieve Bronze Medal" category="Medals"]
+bool setting_show_time_to_bronze = false;
+[Setting name="Show Time To Achieve Silver Medal" category="Medals"]
+bool setting_show_time_to_silver = false;
+[Setting name="Show Time To Achieve Gold Medal" category="Medals"]
+bool setting_show_time_to_gold = true;
+[Setting name="Show Time To Achieve Author Medal" category="Medals"]
+bool setting_show_time_to_author = true;
+
+#else
+
+bool setting_show_respawns_current = false;
+bool setting_show_respawns_session = false;
+bool setting_show_respawns_total = false;
+bool setting_show_time_to_bronze = false;
+bool setting_show_time_to_silver = false;
+bool setting_show_time_to_gold = false;
+bool setting_show_time_to_author = false;
+#endif
+
+[Setting name="Idle Detection Speed" category="Idle" description="The speed where the car will be considered idle after a set time. (this is not the speed that the car is going but the internal value of the speed)"]
+uint setting_idle_speed = 2;
+[Setting name="Idle Detection Delay" category="Idle" description="The amount of time before Idling will begin."]
+uint setting_idle_time = 5;
+
+[Setting name="Show debug information" category="Debug"]
+bool setting_show_debug = false;


### PR DESCRIPTION
_User facing_
* medal achievement time tracking
* new settings tab and accompanying settings for displaying medal times in the main tracker ui
* new setting for showing fractions of second (and added a description to the thousandth digit setting)
* recap ui shows medal times with headers showing completion percentage
* made the opacity of the recap ui a bit less transparent for better readability
* moved 'Last Played' column to last position for all games
* fixed bug where respawn related settings weren't working correctly

_Internals_
* moved settings to a separate file
* extracted colors as constants to a separate file
* removed duplicated folder_location definitions, moved to root file and logic for checking/creating folder to main()
* some code quality polish (whitespaces, etc)