### PR TITLE
MP4 fixes, recap table improvements

### DIFF
--- a/src/Medals/Medals.as
+++ b/src/Medals/Medals.as
@@ -195,6 +195,9 @@ class Medals : BaseComponent {
 #elif TURBO
 		auto map = app.Challenge;
 #endif
+		if (map is null)
+			return 0;
+
 #if TMNEXT
 		if (network.ClientManiaAppPlayground !is null) {
 			auto user_mgr = network.ClientManiaAppPlayground.UserMgr;
@@ -206,8 +209,6 @@ class Medals : BaseComponent {
 			}
 
 			auto score_mgr = app.Network.ClientManiaAppPlayground.ScoreMgr;
-			if (map is null)
-				return 0;
 			uint pb_time = score_mgr.Map_GetRecord_v2(user_id, map.MapInfo.MapUid, "PersonalBest", "", "TimeAttack", "");
 			return pb_time;
 		}

--- a/src/Recap/Recap.as
+++ b/src/Recap/Recap.as
@@ -394,20 +394,24 @@ class Recap {
 
 				for (uint i = 1; i <= maps.Length; i++) {
 					Json::Value @map = maps[maps.Length - i];
-					RecapElement @elem = elements[cur_uid - i];
 
-					if (elem.map_id != map['TrackUID'])
-						continue;
+					for (uint e = i; e <= maps.Length; e++) {
+						RecapElement @elem = elements[cur_uid - e];
 
-					elem.name = format_string(map['GbxMapName']);
-					elem.titlepack = map['TitlePack'];
+						if (elem.map_id == map['TrackUID']) {
+							elem.name = format_string(map['GbxMapName']);
+							elem.titlepack = map['TitlePack'];
 
-					elem.stripped_name = Text::StripFormatCodes(elem.name).Replace('\\','');
-					for (int j = 0; j < elem.stripped_name.Length; j++) {
-						if (elem.stripped_name.StartsWith(" "))
-							elem.stripped_name = elem.stripped_name.SubStr(2);
-						else
+							elem.stripped_name = Text::StripFormatCodes(elem.name).Replace('\\','');
+							for (int j = 0; j < elem.stripped_name.Length; j++) {
+								if (elem.stripped_name.StartsWith(" "))
+									elem.stripped_name = elem.stripped_name.SubStr(2);
+								else
+									break;
+							}
+
 							break;
+						}
 					}
 				}
 			}

--- a/src/Recap/Recap.as
+++ b/src/Recap/Recap.as
@@ -374,15 +374,18 @@ class Recap {
 	}
 
   private void get_all_tm2_names_from_api() {
-		uint req_uid_limit = 8, cur_uid = 0;
-		while (cur_uid < elements.Length) {
-			string map_uids = elements[cur_uid++].map_id;
-			for (uint i = 1; i < req_uid_limit && cur_uid < elements.Length; i++, cur_uid++)
-				map_uids += "," + elements[cur_uid].map_id;
+		uint req_uid_limit = 8;
+
+		for (uint cur_uid = 0; cur_uid < elements.Length; cur_uid += req_uid_limit) {
+			string[] map_uids = array<string>();
+
+			for (uint i = cur_uid; i < cur_uid + req_uid_limit && i < elements.Length; i++) {
+				map_uids.InsertLast(elements[i].map_id);
+			}
 
 			auto req = Net::HttpRequest();
 			req.Method = Net::HttpMethod::Get;
-			req.Url = 'https://tm.mania.exchange/api/maps/get_map_info/multi/' + map_uids;
+			req.Url = 'https://tm.mania.exchange/api/maps/get_map_info/multi/' + string::Join(map_uids, ",");
 			req.Start();
 			while (!req.Finished())
 				yield();
@@ -392,11 +395,11 @@ class Recap {
 			if (req.ResponseCode() == 200 && resp_str != "") {
 				Json::Value @maps = Json::Parse(resp_str);
 
-				for (uint i = 1; i <= maps.Length; i++) {
-					Json::Value @map = maps[maps.Length - i];
+				for (uint m = 0; m < maps.Length; m++) {
+					Json::Value @map = maps[m];
 
-					for (uint e = i; e <= maps.Length; e++) {
-						RecapElement @elem = elements[cur_uid - e];
+					for (uint e = cur_uid; e < cur_uid + req_uid_limit && e < elements.Length; e++) {
+						RecapElement @elem = elements[e];
 
 						if (elem.map_id == map['TrackUID']) {
 							elem.name = format_string(map['GbxMapName']);

--- a/src/Recap/RecapUI.as
+++ b/src/Recap/RecapUI.as
@@ -157,7 +157,7 @@ void RenderRecap() {
 			}
 		}
 
-		if (load_recap && UI::BeginTable("Items", columns, UI::TableFlags::Sortable | UI::TableFlags::Resizable | UI::TableFlags::ScrollY)) {
+		if (load_recap && UI::BeginTable("Items", columns, UI::TableFlags::Sortable | UI::TableFlags::Resizable | UI::TableFlags::ScrollY | UI::TableFlags::RowBg)) {
 			UI::TableSetupScrollFreeze(0, 1);
 			UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::NoHide, 200);
 			UI::TableSetupColumn("Time", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::DefaultSort | UI::TableColumnFlags::PreferSortDescending | UI::TableColumnFlags::NoHide, 150);

--- a/src/Recap/RecapUI.as
+++ b/src/Recap/RecapUI.as
@@ -158,6 +158,7 @@ void RenderRecap() {
 		}
 
 		if (load_recap && UI::BeginTable("Items", columns, UI::TableFlags::Sortable | UI::TableFlags::Resizable | UI::TableFlags::ScrollY)) {
+			UI::TableSetupScrollFreeze(0, 1);
 			UI::TableSetupColumn("Name", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::NoHide, 200);
 			UI::TableSetupColumn("Time", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::DefaultSort | UI::TableColumnFlags::PreferSortDescending | UI::TableColumnFlags::NoHide, 150);
 			UI::TableSetupColumn("Finishes", UI::TableColumnFlags::WidthFixed, 100);
@@ -206,6 +207,7 @@ void RenderRecap() {
 					}
 					UI::TableNextRow();
 					UI::TableSetColumnIndex(0);
+					UI::AlignTextToFramePadding();
 					UI::Text(setting_recap_show_colors ? name : stripped_name);
 					if (UI::IsItemHovered() && Meta::IsDeveloperMode()) {
 						UI::BeginTooltip();


### PR DESCRIPTION
* Check if map is null for every game instead of just TM2020. This fixes the script exceptions when loading/exiting a map on MP4 (and probably Turbo too)
* Use a second for loop to find a matching UID when looping TM2 Exchange's API response. This won't load the maps that are not on MX of course, but it loads the maps that were after the missing UID. See #53
* Adds alternate background color for the rows in the recap table. Here's how it looks

![20241122174339_1](https://github.com/user-attachments/assets/120c6f5d-52a1-467f-87fc-09decf656022)

* Freeze table header (see screenshot above) and align rows text

Fixes #53
Closes #41 (hopefully)
