### PR TITLE
Add environment filters/column for Turbo, fix sorting cases for non TMNEXT games

### DIFF
--- a/src/Recap/Recap.as
+++ b/src/Recap/Recap.as
@@ -281,16 +281,16 @@ class Recap {
 			this.filter_turbo(Recap::turbo_filter::black);
 			break;
 		case recap_filter::canyon:
-			this.filter_titlePack(Recap::turbo_filter::canyon);
+			this.filter_environment(Recap::turbo_filter::canyon);
 			break;
 		case recap_filter::stadium:
-			this.filter_titlePack(Recap::turbo_filter::stadium);
+			this.filter_environment(Recap::turbo_filter::stadium);
 			break;
 		case recap_filter::valley:
-			this.filter_titlePack(Recap::turbo_filter::valley);
+			this.filter_environment(Recap::turbo_filter::valley);
 			break;
 		case recap_filter::lagoon:
-			this.filter_titlePack(Recap::turbo_filter::lagoon);
+			this.filter_environment(Recap::turbo_filter::lagoon);
 			break;
 #endif
 		default:
@@ -456,34 +456,11 @@ class Recap {
 		}
 	}
 #elif TURBO
-  private void filter_titlePack(Recap::turbo_filter filter) {
+  private void filter_environment(Recap::turbo_filter filter) {
 		for (uint i = 0; i < elements.Length; i++) {
 			RecapElement @element = elements[i];
-			int num = Text::ParseInt(element.stripped_name);
-			int numMod40 = num % 40;
-			switch (filter) {
-			case Recap::turbo_filter::canyon:
-				if (numMod40 >= 1 && numMod40 <= 10) {
-					filtered_elements.InsertLast(element);
-				}
-				break;
-			case Recap::turbo_filter::stadium:
-				if (numMod40 >= 11 && numMod40 <= 20) {
-					filtered_elements.InsertLast(element);
-				}
-				break;
-			case Recap::turbo_filter::valley:
-				if (numMod40 >= 21 && numMod40 <= 30) {
-					filtered_elements.InsertLast(element);
-				}
-				break;
-			case Recap::turbo_filter::lagoon:
-				if (numMod40 >= 31 && numMod40 <= 40 || numMod40 == 0) {
-					filtered_elements.InsertLast(element);
-				}
-				break;
-			default:
-				break;
+			if (element.environment.ToLower() == tostring(filter)) {
+				filtered_elements.InsertLast(element);
 			}
 		}
 	}

--- a/src/Recap/Recap.as
+++ b/src/Recap/Recap.as
@@ -155,7 +155,13 @@ class Recap {
 				result = int(a.resets - b.resets);
 				break;
 			case 4:
+#if TMNEXT
 				result = int(a.respawns - b.respawns);
+#elif MP4
+				result = a.titlepack.ToLower() > b.titlepack.ToLower() ? -1 : 1;
+#else
+				result = a.environment.ToLower() > b.environment.ToLower() ? -1 : 1;
+#endif
 				break;
 			case 5:
 				result = int(a.modified_time - b.modified_time);

--- a/src/Recap/RecapElement.as
+++ b/src/Recap/RecapElement.as
@@ -11,6 +11,8 @@ class RecapElement {
 	int64 modified_time;
 #if MP4
 	string titlepack;
+#elif TURBO
+	string environment;
 #endif
 
 	RecapElement() {}
@@ -99,6 +101,7 @@ class RecapElement {
 					}
 				}
 				name = color + infos[i].NameForUi;
+				environment = get_environment_name(infos[i].NameForUi);
 			}
 		}
 #endif
@@ -111,4 +114,26 @@ class RecapElement {
 				break;
 		}
 	}
+
+#if TURBO
+	string get_environment_name(const string &in mapName) {
+		int num;
+
+		if (!Text::TryParseInt(mapName, num))
+			return "";
+
+		int numMod40 = num % 40;
+
+		if (numMod40 >= 1 && numMod40 <= 10)
+			return "Canyon";
+		else if (numMod40 >= 11 && numMod40 <= 20)
+			return "Valley";
+		else if (numMod40 >= 21 && numMod40 <= 30)
+			return "Lagoon";
+		else if (numMod40 >= 31 && numMod40 <= 40 || numMod40 == 0)
+			return "Stadium";
+
+		return "";
+	}
+#endif
 }

--- a/src/Recap/RecapUI.as
+++ b/src/Recap/RecapUI.as
@@ -106,12 +106,13 @@ void RenderRecap() {
 				add_selectable(recap_filter::all_nadeo_campaigns);
 				add_selectable(recap_filter::totd);
 				add_selectable(recap_filter::custom);
-#elif MP4
+#elif MP4 || TURBO
 				add_selectable(recap_filter::canyon);
 				add_selectable(recap_filter::stadium);
 				add_selectable(recap_filter::valley);
 				add_selectable(recap_filter::lagoon);
-#elif TURBO
+#endif
+#if TURBO
 				add_selectable(recap_filter::turbo_white);
 				add_selectable(recap_filter::turbo_green);
 				add_selectable(recap_filter::turbo_blue);
@@ -127,11 +128,7 @@ void RenderRecap() {
 			UI::EndMenuBar();
 		}
 
-#if TURBO
-		uint columns = 6;
-#elif MP4 || TMNEXT
 		uint columns = 7;
-#endif
 
 		if (!load_recap) {
 			auto windowWidth = UI::GetWindowSize();
@@ -168,6 +165,8 @@ void RenderRecap() {
 			UI::TableSetupColumn("Respawns", UI::TableColumnFlags::WidthFixed, 100);
 #elif MP4
 			UI::TableSetupColumn("Title pack", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::NoResize, 100);
+#elif TURBO
+			UI::TableSetupColumn("Environment", UI::TableColumnFlags::WidthFixed | UI::TableColumnFlags::NoResize, 100);
 #endif
 			UI::TableSetupColumn("Last Played", UI::TableColumnFlags::WidthFixed, 100);
 			UI::TableSetupColumn("Custom Recap", UI::TableColumnFlags::WidthFixed, 100);
@@ -183,6 +182,8 @@ void RenderRecap() {
 					string name, map_id, time, finishes, resets, respawns, stripped_name, time_modified;
 #if MP4
 					string titlepack;
+#elif TURBO
+					string environment;
 #endif
 					if (i != 0) {
 						RecapElement @element = recap.filtered_elements[i - 1];
@@ -196,6 +197,8 @@ void RenderRecap() {
 						time_modified = Time::FormatString("%F %r", element.modified_time);
 #if MP4
 						titlepack = element.titlepack;
+#elif TURBO
+						environment = element.environment;
 #endif
 					} else {
 						map_id = "";
@@ -224,25 +227,18 @@ void RenderRecap() {
 					UI::Text(finishes);
 					UI::TableSetColumnIndex(3);
 					UI::Text(resets);
-#if TMNEXT
 					UI::TableSetColumnIndex(4);
+#if TMNEXT
 					UI::Text(respawns);
 #elif MP4
-					UI::TableSetColumnIndex(4);
 					UI::Text(titlepack);
+#elif TURBO
+					UI::Text(environment);
 #endif
-#if TURBO
-					UI::TableSetColumnIndex(4);
-#else
 					UI::TableSetColumnIndex(5);
-#endif
 					UI::Text(time_modified);
 					if (i != 0) {
-#if TURBO
-						UI::TableSetColumnIndex(5);
-#else
 						UI::TableSetColumnIndex(6);
-#endif
 						bool is_cust_map = setting_custom_recap.Contains(map_id);
 						if (UI::Checkbox("##" + map_id, is_cust_map) != is_cust_map) {
 							if (is_cust_map)


### PR DESCRIPTION
This PR adds the Turbo environment filters to the recap. To get the environment, we use the campaign map number (e.g. \#200 is Stadium). The main issue with this is not being able to get the environment for non campaign maps, but I don't think there's an API endpoint to get this information anyway

It also adds the environment column to the recap, just like the title pack one in MP4. This means having the same amount of columns when setting up the table in all games, cleaning some of the code

Finally, it fixes case 4 in the switch statement when sorting the recap. Previously, it would try to sort the entries by respawns regardless of the game, despite Turbo/MP4 not keeping track of this value

P.S.: I can provide screenshots/videos of the new filters/column working on Turbo if needed

Closes #34