### PR TITLE
Migrate MX endpoints to 2.0

### DIFF
--- a/src/Recap/Recap.as
+++ b/src/Recap/Recap.as
@@ -415,7 +415,7 @@ class Recap {
 	}
 
   private void get_all_tm2_names_from_api() {
-		uint req_uid_limit = 8;
+		uint req_uid_limit = 50;
 
 		for (uint cur_uid = 0; cur_uid < elements.Length; cur_uid += req_uid_limit) {
 			string[] map_uids = array<string>();
@@ -426,7 +426,7 @@ class Recap {
 
 			auto req = Net::HttpRequest();
 			req.Method = Net::HttpMethod::Get;
-			req.Url = 'https://tm.mania.exchange/api/maps/get_map_info/multi/' + string::Join(map_uids, ",");
+			req.Url = 'https://tm.mania.exchange/api/maps?fields=GbxMapName,TitlePack,MapUid&count=' + (req_uid_limit + 10) + '&uid=' + string::Join(map_uids, ",");
 			req.Start();
 			while (!req.Finished())
 				yield();
@@ -434,7 +434,7 @@ class Recap {
 			string resp_str = req.String();
 
 			if (req.ResponseCode() == 200 && resp_str != "") {
-				Json::Value @maps = Json::Parse(resp_str);
+				Json::Value @maps = Json::Parse(resp_str)["Results"];
 
 				for (uint m = 0; m < maps.Length; m++) {
 					Json::Value @map = maps[m];
@@ -442,7 +442,7 @@ class Recap {
 					for (uint e = cur_uid; e < cur_uid + req_uid_limit && e < elements.Length; e++) {
 						RecapElement @elem = elements[e];
 
-						if (elem.map_id == map['TrackUID']) {
+						if (elem.map_id == map['MapUid']) {
 							elem.name = format_string(map['GbxMapName']);
 							elem.titlepack = map['TitlePack'];
 

--- a/src/Recap/RecapElement.as
+++ b/src/Recap/RecapElement.as
@@ -64,14 +64,15 @@ class RecapElement {
 #elif MP4
 		auto req = Net::HttpRequest();
 		req.Method = Net::HttpMethod::Get;
-		req.Url = 'https://tm.mania.exchange/api/maps/get_map_info/uid/' + this.map_id;
+		req.Url = 'https://tm.mania.exchange/api/maps?fields=GbxMapName,TitlePack&count=1&uid=' + this.map_id;
 		req.Start();
 		while (!req.Finished())
 			yield();
-		Json::Value @map = Json::Parse(req.String());
-		if (map.Length > 0) {
-			name = format_string(map[0]['GbxMapName']);
-			titlepack = string(map[0]['TitlePack']);
+		Json::Value @res = req.Json();
+		if (req.ResponseCode() == 200 && res["Results"].Length > 0) {
+			Json::Value @map = res["Results"][0];
+			name = format_string(map['GbxMapName']);
+			titlepack = string(map['TitlePack']);
 		}
 
 #elif TURBO


### PR DESCRIPTION
Basically what the title says, migrates the endpoints used by the plugin to 2.0. This also allows us to get 50 maps at once instead of just 8

P.S.: We do `req_uid_limit + 10` in Recap.as because a few maps on MX contain the same UID (really rare, but can happen)