### PR TITLE
Only show totals when it's higher than current/session

### DIFF
--- a/src/Components/Finishes.as
+++ b/src/Components/Finishes.as
@@ -19,7 +19,7 @@ class Finishes : BaseComponent {
 			if (setting_show_finishes_session)
 				string_constructor.InsertLast("\\$bbb" + session);
 
-			if (setting_show_finishes_total && total != session)
+			if (setting_show_finishes_total && total > session)
 				string_constructor.InsertLast("\\$bbb" + total);
 		}
 

--- a/src/Components/Resets.as
+++ b/src/Components/Resets.as
@@ -19,7 +19,7 @@ class Resets : BaseComponent {
 			if (setting_show_resets_session)
 				string_constructor.InsertLast("\\$bbb" + session);
 
-			if (setting_show_resets_total && total != session)
+			if (setting_show_resets_total && total > session)
 				string_constructor.InsertLast("\\$bbb" + total);
 		}
 

--- a/src/Components/Respawns.as
+++ b/src/Components/Respawns.as
@@ -31,10 +31,10 @@ class Respawns : BaseComponent {
 
 			if (setting_show_respawns_total) {
 				bool showTotal = true;
-				if (total == current && setting_show_respawns_current) {
+				if (total <= current && setting_show_respawns_current) {
 					showTotal = false;
 				}
-				if (total == session && setting_show_respawns_session) {
+				if (total <= session && setting_show_respawns_session) {
 					showTotal = false;
 				}
 				if (showTotal) {


### PR DESCRIPTION
Partially addresses #57, but doesn't fix the root cause (Most likely autosaves). This should avoid similar issues in the future