### PR TITLE
Personal bests history

### DIFF
--- a/src/Components/PersonalBests.as
+++ b/src/Components/PersonalBests.as
@@ -6,6 +6,7 @@ class PersonalBestData {
 	uint64 finishes;
 	uint64 resets;
 	uint64 respawns;
+	bool unmonitored; // For records that were not fully monitored and for which grindstats are unreliable.
 
 	PersonalBestData() {}
 
@@ -31,6 +32,8 @@ class PersonalBestData {
 		finishes = uint64(double(pb_object["finishes"]));
 		resets = uint64(double(pb_object["resets"]));
 		respawns = uint64(double(pb_object["respawns"]));
+		if (pb_object.HasKey('unmonitored'))
+			unmonitored = true;
 	}
 
 	Json::Value toJson() {
@@ -40,6 +43,8 @@ class PersonalBestData {
 		json['finishes'] = finishes;
 		json['resets'] = resets;
 		json['respawns'] = respawns;
+		if (unmonitored)
+			json['unmonitored'] = true;
 		return json;
 	}
 }
@@ -117,6 +122,18 @@ class PersonalBests : BaseComponent {
 			grindstats.resetsComponent.total,
 			grindstats.respawnsComponent.total
 		));
+	}
+
+	// If the user has a PB on the map that the GrindingStats JSON didn't know about, record it.
+	void record_unmonitored_pb_if_any() {
+		if (personalbests.Length > 0)
+			return; 
+		uint pb_time = get_pb_time();
+		if (pb_time == 0 or pb_time == uint(-1))
+			return;
+		record_personalbest(pb_time);
+		personalbests[0].unmonitored = true;
+		print("PersonalBests: recorded previsouly unmonitored PB: " + toString());
 	}
 
 	Json::Value toJson() {

--- a/src/Components/PersonalBests.as
+++ b/src/Components/PersonalBests.as
@@ -58,6 +58,7 @@ class PersonalBests : BaseComponent {
 			throw("Expected Json::Type::Array, received enum type " + pbs_array.GetType());
 		for(uint i = 0 ; i < pbs_array.Length ; i++)
 			personalbests.InsertLast(PersonalBestData(pbs_array[i]));
+		debug_print("Loaded PB history: " + toString());
 	}
 
 	~PersonalBests() { running = false; }
@@ -84,7 +85,7 @@ class PersonalBests : BaseComponent {
 		auto ui_sequence = terminal.UISequence_Current;
 		if (ui_sequence != CGamePlaygroundUIConfig::EUISequence::Finish) {
 			if(handled) {
-				print("PersonalBests : reseting handling flag.");
+				debug_print("Reseting handling flag.");
 				handled = false;
 			}
 			return;
@@ -95,14 +96,17 @@ class PersonalBests : BaseComponent {
 
 		// New finish, check if it's a new PB.
 		// TODO: 2025-04-27 Can other grindstats coroutines be seriously out of sync ?
-		print("PersonalBests : handling new finish.");
+		debug_print("Handling new finish.");
 		uint pb_time = get_pb_time();
 		if (pb_time == uint(-1))
 			return;
-		print("Present PB = " + pb_time +
-			" ; vs previously known PB = " + (personalbests.Length == 0 ? "None" : Text::Format("%d", personalbests[0].achieved_time)));
-		if (personalbests.Length == 0 || pb_time < personalbests[0].achieved_time)
+		debug_print("Present PB = " + pb_time +
+			" ; vs previously known PB = " +
+			(personalbests.Length == 0 ? "None" : Text::Format("%d", personalbests[0].achieved_time)));
+		if (personalbests.Length == 0 || pb_time < personalbests[0].achieved_time) {
 			record_personalbest(pb_time);
+			debug_print("New PB! Current PBs: " + toString());
+		}
 #endif
 	}
 
@@ -127,6 +131,7 @@ class PersonalBests : BaseComponent {
 			return;
 		record_personalbest(pb_time);
 		personalbests[0].unmonitored = true;
+		debug_print("Recorded unmonitored PB: " + toString());
 	}
 
 	Json::Value toJson() {
@@ -138,6 +143,10 @@ class PersonalBests : BaseComponent {
 
 	string toString() override {
 		return Json::Write(toJson());
+	}
+
+	void debug_print(string s) {
+		// print("PersonalBests: " + s);
 	}
 
 	uint get_pb_time() {

--- a/src/Components/PersonalBests.as
+++ b/src/Components/PersonalBests.as
@@ -1,0 +1,137 @@
+#if TMNEXT
+
+class PersonalBestData {
+	uint64 achieved_time;
+	uint64 time_played;
+	uint64 finishes;
+	uint64 resets;
+	uint64 respawns;
+
+	PersonalBestData() {}
+
+	PersonalBestData(
+			uint64 _achieved_time,
+			uint64 _time_played,
+			uint64 _finishes,
+			uint64 _resets,
+			uint64 _respawns
+			) {
+		achieved_time = _achieved_time;
+		time_played = _time_played;
+		finishes = _finishes;
+		resets = _resets;
+		respawns = _respawns;
+	}
+
+	PersonalBestData(Json::Value pb_object) {
+		if ( pb_object.GetType() != Json::Type::Object )
+			throw("Expected Json::Type::Object, received type #" + pb_object.GetType());
+		achieved_time = uint64(double(pb_object["achieved_time"]));
+		time_played = uint64(double(pb_object["time_played"]));
+		finishes = uint64(double(pb_object["finishes"]));
+		resets = uint64(double(pb_object["resets"]));
+		respawns = uint64(double(pb_object["respawns"]));
+	}
+
+	Json::Value toJson() {
+		Json::Value json = Json::Object();
+		json['achieved_time'] = achieved_time;
+		json['time_played'] = time_played;
+		json['finishes'] = finishes;
+		json['resets'] = resets;
+		json['respawns'] = respawns;
+		return json;
+	}
+}
+
+class PersonalBests : BaseComponent {
+	protected array<PersonalBestData@> personalbests; // With current PB at index 0 (if any).
+	const AbstractData @grindstats;
+
+	PersonalBests() {}
+
+	PersonalBests(Json::Value pbs_array) {
+		if ( pbs_array.GetType() != Json::Type::Array )
+			throw("Expected Json::Type::Array, received type #" + pbs_array.GetType());
+		for(uint i = 0 ; i < pbs_array.Length ; i++ )
+			personalbests.InsertLast(PersonalBestData(pbs_array[i]));
+		print("Loaded " + personalbests.Length + " PBs: " + toString());
+	}
+
+	~PersonalBests() { running = false; }
+
+	void handler() override {
+		while (this.running) {
+			check_for_finish();
+			yield();
+		}
+	}
+
+	void check_for_finish() {
+#if TMNEXT
+		auto app = GetApp();
+		if (app.RootMap is null)
+			return;
+		auto playground = app.CurrentPlayground;
+		if (playground is null || playground.GameTerminals.Length == 0)
+			return;
+		auto terminal = playground.GameTerminals[0];
+		auto gui_player = cast<CSmPlayer>(terminal.GUIPlayer);
+		if(gui_player is null)
+			return;
+		auto ui_sequence = terminal.UISequence_Current;
+		if (ui_sequence != CGamePlaygroundUIConfig::EUISequence::Finish) {
+			if(handled) {
+				print("PersonalBests : reseting handling flag.");
+				handled = false;
+			}
+			return;
+		}
+		if (handled)
+			return;
+		handled = true;
+
+		// New finish, handle it.
+		print("PersonalBests : handling new finish.");
+		auto network = cast<CTrackManiaNetwork>(app.Network);
+		if (network.ClientManiaAppPlayground is null)
+			return;
+		auto score_mgr = network.ClientManiaAppPlayground.ScoreMgr;
+		auto user_mgr = network.ClientManiaAppPlayground.UserMgr;
+		if (user_mgr.Users.Length == 0)
+			return;
+		MwId user_id = user_mgr.Users[0].Id;
+		string mapuid = app.RootMap.MapInfo.MapUid;
+		uint pb_time = score_mgr.Map_GetRecord_v2(user_id, mapuid, "PersonalBest", "", "TimeAttack", "");
+		if (pb_time == uint(-1))
+			return;
+		print("Present PB = " + pb_time + " ; " +
+			"previously known PB = " + (personalbests.Length == 0 ? "None" : Text::Format("%d", personalbests[0].achieved_time)));
+		if (personalbests.Length == 0 || pb_time < personalbests[0].achieved_time) {
+			// New PB, record it.
+			// TODO: 2025-04-27 Can other coroutines be seriously out of sync ?
+			print("PersonalBests : new personal best.");
+			personalbests.InsertAt(0, PersonalBestData(
+				pb_time,
+				grindstats.timerComponent.total,
+				grindstats.finishesComponent.total,
+				grindstats.resetsComponent.total,
+				grindstats.respawnsComponent.total
+			));
+		}
+#endif
+	}
+
+	Json::Value toJson() {
+		Json::Value@ json = Json::Array();
+		for ( uint i = 0; i < personalbests.Length; i++ )
+			json.Add(personalbests[i].toJson());
+		return json;
+	}
+
+	string toString() override {
+		return Json::Write(toJson());
+	}
+}
+
+#endif

--- a/src/Components/PersonalBests.as
+++ b/src/Components/PersonalBests.as
@@ -10,13 +10,11 @@ class PersonalBestData {
 
 	PersonalBestData() {}
 
-	PersonalBestData(
-			uint64 _achieved_time,
-			uint64 _time_played,
-			uint64 _finishes,
-			uint64 _resets,
-			uint64 _respawns
-			) {
+	PersonalBestData(uint64 _achieved_time,
+					 uint64 _time_played,
+					 uint64 _finishes,
+					 uint64 _resets,
+					 uint64 _respawns) {
 		achieved_time = _achieved_time;
 		time_played = _time_played;
 		finishes = _finishes;
@@ -25,8 +23,8 @@ class PersonalBestData {
 	}
 
 	PersonalBestData(Json::Value pb_object) {
-		if ( pb_object.GetType() != Json::Type::Object )
-			throw("Expected Json::Type::Object, received type #" + pb_object.GetType());
+		if (pb_object.GetType() != Json::Type::Object)
+			throw("Expected Json::Type::Object, received enum type " + pb_object.GetType());
 		achieved_time = uint64(double(pb_object["achieved_time"]));
 		time_played = uint64(double(pb_object["time_played"]));
 		finishes = uint64(double(pb_object["finishes"]));
@@ -56,11 +54,10 @@ class PersonalBests : BaseComponent {
 	PersonalBests() {}
 
 	PersonalBests(Json::Value pbs_array) {
-		if ( pbs_array.GetType() != Json::Type::Array )
-			throw("Expected Json::Type::Array, received type #" + pbs_array.GetType());
-		for(uint i = 0 ; i < pbs_array.Length ; i++ )
+		if (pbs_array.GetType() != Json::Type::Array)
+			throw("Expected Json::Type::Array, received enum type " + pbs_array.GetType());
+		for(uint i = 0 ; i < pbs_array.Length ; i++)
 			personalbests.InsertLast(PersonalBestData(pbs_array[i]));
-		print("Loaded " + personalbests.Length + " PBs: " + toString());
 	}
 
 	~PersonalBests() { running = false; }
@@ -96,19 +93,16 @@ class PersonalBests : BaseComponent {
 			return;
 		handled = true;
 
-		// New finish, handle it.
-		// TODO: 2025-04-27 Can other coroutines be seriously out of sync ?
+		// New finish, check if it's a new PB.
+		// TODO: 2025-04-27 Can other grindstats coroutines be seriously out of sync ?
 		print("PersonalBests : handling new finish.");
 		uint pb_time = get_pb_time();
 		if (pb_time == uint(-1))
 			return;
-		print("Present PB = " + pb_time + " ; " +
-			"previously known PB = " + (personalbests.Length == 0 ? "None" : Text::Format("%d", personalbests[0].achieved_time)));
-		if (personalbests.Length == 0 || pb_time < personalbests[0].achieved_time) {
-			// New PB, record it.
-			print("PersonalBests : new personal best.");
+		print("Present PB = " + pb_time +
+			" ; vs previously known PB = " + (personalbests.Length == 0 ? "None" : Text::Format("%d", personalbests[0].achieved_time)));
+		if (personalbests.Length == 0 || pb_time < personalbests[0].achieved_time)
 			record_personalbest(pb_time);
-		}
 #endif
 	}
 
@@ -133,12 +127,11 @@ class PersonalBests : BaseComponent {
 			return;
 		record_personalbest(pb_time);
 		personalbests[0].unmonitored = true;
-		print("PersonalBests: recorded previsouly unmonitored PB: " + toString());
 	}
 
 	Json::Value toJson() {
 		Json::Value@ json = Json::Array();
-		for ( uint i = 0; i < personalbests.Length; i++ )
+		for (uint i = 0; i < personalbests.Length; i++)
 			json.Add(personalbests[i].toJson());
 		return json;
 	}

--- a/src/Data/AbstractData.as
+++ b/src/Data/AbstractData.as
@@ -12,6 +12,7 @@ abstract class AbstractData {
 	Respawns @respawnsComponent = Respawns(0);
 	Timer @timerComponent = Timer(0);
 	Medals @medalsComponent = Medals();
+	PersonalBests @personalBestsComponent = PersonalBests();
 
 	AbstractData() {}
 
@@ -30,6 +31,7 @@ abstract class AbstractData {
 		resetsComponent.start();
 		respawnsComponent.start();
 		medalsComponent.start();
+		personalBestsComponent.start();
 	}
 
 	void overwrite(AbstractData @other) {

--- a/src/Data/Files.as
+++ b/src/Data/Files.as
@@ -43,6 +43,7 @@ class Files : AbstractData {
 		create_components();
 		personalBestsComponent = PersonalBests(personalbests_json);
 		@personalBestsComponent.grindstats = this;
+		personalBestsComponent.record_unmonitored_pb_if_any();
 	}
 
 	void create_components() {

--- a/src/Data/Files.as
+++ b/src/Data/Files.as
@@ -16,6 +16,7 @@ class Files : AbstractData {
 
 	void load() override {
 
+		Json::Value personalbests_json = Json::Array();
 		if (IO::FileExists(file_location)) {
 			auto content = Json::FromFile(file_location);
 			try {
@@ -24,6 +25,7 @@ class Files : AbstractData {
 				time = Text::ParseUInt64(content.Get('time', "0"));
 				respawns = Text::ParseUInt64(content.Get('respawns', "0"));
 				medals_string = content.Get('medals', "");
+				personalbests_json = content.Get('personal_bests', "[]");
 			} catch {
 				debug_print("Failed to parse file, attempting to read old format");
 				finishes = content.Get("finishes", "0");
@@ -31,6 +33,7 @@ class Files : AbstractData {
 				time = content.Get('time', "0");
 				respawns = content.Get('respawns', "0");
 				medals_string = content.Get('medals', "");
+				personalbests_json = content.Get('personal_bests', "[]");
 			}
 		}
 		if (medals_string == "" || medals_string == "[]")
@@ -38,6 +41,8 @@ class Files : AbstractData {
 		debug_print("Read finishes " + finishes + " resets " + resets + " time " + time +
 					" respawns " + respawns + "\nmedals " + medals_string + "\nfrom " + file_location);
 		create_components();
+		personalBestsComponent = PersonalBests(personalbests_json);
+		@personalBestsComponent.grindstats = this;
 	}
 
 	void create_components() {
@@ -70,6 +75,7 @@ class Files : AbstractData {
 		content["time"] = Text::Format("%11d", time);
 		content["respawns"] = Text::Format("%6d", respawns);
 		content["medals"] = medals_string;
+		content["personal_bests"] = personalBestsComponent.toJson();
 
 		Json::ToFile(file_location, content);
 

--- a/src/Data/Files.as
+++ b/src/Data/Files.as
@@ -25,7 +25,7 @@ class Files : AbstractData {
 				time = Text::ParseUInt64(content.Get('time', "0"));
 				respawns = Text::ParseUInt64(content.Get('respawns', "0"));
 				medals_string = content.Get('medals', "");
-				personalbests_json = content.Get('personal_bests', "[]");
+				personalbests_json = content.Get('personal_bests', Json::Array());
 			} catch {
 				debug_print("Failed to parse file, attempting to read old format");
 				finishes = content.Get("finishes", "0");
@@ -33,7 +33,7 @@ class Files : AbstractData {
 				time = content.Get('time', "0");
 				respawns = content.Get('respawns', "0");
 				medals_string = content.Get('medals', "");
-				personalbests_json = content.Get('personal_bests', "[]");
+				personalbests_json = content.Get('personal_bests', Json::Array());
 			}
 		}
 		if (medals_string == "" || medals_string == "[]")


### PR DESCRIPTION
Hello Drek! Here's my temptative implementation for https://github.com/drekdrek/grinding-stats/issues/61 (saving stats at every PB).

What do you think? I'm new to Openplanet/TM plugins so I'm not too sure where I may have f**ked up somewhere. My additions are hopefully understandable, but let me know if it's not... It does what's proposed in the Issue tracker.

I've tested it on the Openplanet School maps, and it seems to work. I haven't been thorough yet. You can uncomment `debug_print()` in the new component if you want the logs.

A couple specific points :

* It seems like I'm occasionally pulling some stale values from `Map_GetRecord_v2()` when checking it after a finish. Then the new time is "discovered" only at the next finish, which is a decent issue in terms of functionality. I haven't really looked into it ; have you run into this problem before?
* I've added an "unmonitored" qualifier for PBs that were not recorded when they were established, as it is the case on maps that have preexisting grind data and PBs.
* At the moment I'm using the Json classes more than the existing code.
* The logs show that there's occasionally multiple instances of the component running in parallel and detecting a new finish at the same time. I've done a bit of testing and I couldn't figure out where the rogue instances come from. It might have to do with the repeated plugin reloading ; honestly I don't know. They don't seem to interfere at all with what the "main" instance is doing though.

Cheers,

Nico