### PR TITLE
Improved component handlers start stop control

### DIFF
--- a/src/Components/BaseComponent.as
+++ b/src/Components/BaseComponent.as
@@ -1,5 +1,5 @@
 class BaseComponent {
-  protected bool running = true;
+  protected bool running = false;
   protected bool handled = false;
   protected array<string> string_constructor;
 

--- a/src/Components/BaseComponent.as
+++ b/src/Components/BaseComponent.as
@@ -14,9 +14,17 @@ class BaseComponent {
 		session = 0;
 	}
 
+	~BaseComponent() {
+		running = false;
+	}
+
 	void start() {
 		running = true;
 		startnew(CoroutineFunc(handler));
+	}
+
+	void stop() {
+		running = false;
 	}
 
   protected void handler() {}

--- a/src/Components/Finishes.as
+++ b/src/Components/Finishes.as
@@ -34,6 +34,7 @@ class Finishes : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
+			yield();
 
 			auto app = GetApp();
 #if TMNEXT || MP4
@@ -42,7 +43,7 @@ class Finishes : BaseComponent {
 			auto map = app.Challenge;
 #endif
 			if (map is null)
-				return;
+				continue;
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -85,7 +86,6 @@ class Finishes : BaseComponent {
 				}
 #endif
 			}
-			yield();
 		}
 	}
 }

--- a/src/Components/Finishes.as
+++ b/src/Components/Finishes.as
@@ -34,16 +34,16 @@ class Finishes : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
-			yield();
-
 			auto app = GetApp();
 #if TMNEXT || MP4
 			auto map = app.RootMap;
 #elif TURBO
 			auto map = app.Challenge;
 #endif
-			if (map is null)
+			if (map is null) {
+				yield();
 				continue;
+			}
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -86,6 +86,7 @@ class Finishes : BaseComponent {
 				}
 #endif
 			}
+			yield();
 		}
 	}
 }

--- a/src/Components/Finishes.as
+++ b/src/Components/Finishes.as
@@ -4,7 +4,7 @@ class Finishes : BaseComponent {
 
 	Finishes(uint64 total) { super(total); }
 
-	~Finishes() { running = false; }
+	~Finishes() {}
 
 	string toString() override {
 		string_constructor = array<string>();

--- a/src/Components/Resets.as
+++ b/src/Components/Resets.as
@@ -3,7 +3,7 @@ class Resets : BaseComponent {
 
 	Resets(uint64 total) { super(total); }
 
-	~Resets() { running = false; }
+	~Resets() {}
 
 	string toString() override {
 		string_constructor = array<string>();

--- a/src/Components/Resets.as
+++ b/src/Components/Resets.as
@@ -34,6 +34,7 @@ class Resets : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
+			yield();
 
 			auto app = GetApp();
 #if TMNEXT || MP4
@@ -42,7 +43,7 @@ class Resets : BaseComponent {
 			auto map = app.Challenge;
 #endif
 			if (map is null)
-				return;
+				continue;
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -86,7 +87,6 @@ class Resets : BaseComponent {
 				}
 #endif
 			}
-			yield();
 		}
 	}
 }

--- a/src/Components/Resets.as
+++ b/src/Components/Resets.as
@@ -34,16 +34,16 @@ class Resets : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
-			yield();
-
 			auto app = GetApp();
 #if TMNEXT || MP4
 			auto map = app.RootMap;
 #elif TURBO
 			auto map = app.Challenge;
 #endif
-			if (map is null)
+			if (map is null) {
+				yield();
 				continue;
+			}
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -87,6 +87,7 @@ class Resets : BaseComponent {
 				}
 #endif
 			}
+			yield();
 		}
 	}
 }

--- a/src/Components/Respawns.as
+++ b/src/Components/Respawns.as
@@ -9,7 +9,7 @@ class Respawns : BaseComponent {
 		current = 0;
 	}
 
-	~Respawns() { running = false; }
+	~Respawns() {}
 
 	string toString() override {
 		string_constructor = array<string>();

--- a/src/Components/Respawns.as
+++ b/src/Components/Respawns.as
@@ -58,11 +58,12 @@ class Respawns : BaseComponent {
 #if TMNEXT
 		uint64 last_respawn_time = 0;
 		while (this.running) {
+			yield();
 
 			auto app = GetApp();
 			auto map = app.RootMap;
 			if (map is null)
-				return;
+				continue;
 			auto playground = app.CurrentPlayground;
 			if (playground !is null && playground.GameTerminals.Length > 0) {
 				auto terminal = playground.GameTerminals[0];
@@ -88,7 +89,6 @@ class Respawns : BaseComponent {
 					}
 				}
 			}
-			yield();
 		}
 #endif
 	}

--- a/src/Components/Respawns.as
+++ b/src/Components/Respawns.as
@@ -58,12 +58,12 @@ class Respawns : BaseComponent {
 #if TMNEXT
 		uint64 last_respawn_time = 0;
 		while (this.running) {
-			yield();
-
 			auto app = GetApp();
 			auto map = app.RootMap;
-			if (map is null)
+			if (map is null) {
+				yield();
 				continue;
+			}
 			auto playground = app.CurrentPlayground;
 			if (playground !is null && playground.GameTerminals.Length > 0) {
 				auto terminal = playground.GameTerminals[0];
@@ -89,6 +89,7 @@ class Respawns : BaseComponent {
 					}
 				}
 			}
+			yield();
 		}
 #endif
 	}

--- a/src/Components/Timer.as
+++ b/src/Components/Timer.as
@@ -89,6 +89,7 @@ class Timer : BaseComponent {
 
 	void keep_time() {
 		while (timing) {
+			yield();
 			auto app = GetApp();
 #if TMNEXT || MP4
 			auto map = app.RootMap;
@@ -96,11 +97,10 @@ class Timer : BaseComponent {
 			auto map = app.Challenge;
 #endif
 			if (map is null)
-				return;
+				continue;
 			current_time = Time::Now;
 			session = (current_time + session_offset) - start_time;
 			total = (current_time + total_offset) - start_time;
-			yield();
 		}
 	}
 
@@ -119,6 +119,7 @@ class Timer : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
+			yield();
 
 			auto app = GetApp();
 #if TMNEXT || MP4
@@ -127,7 +128,7 @@ class Timer : BaseComponent {
 			auto map = app.Challenge;
 #endif
 			if (map is null)
-				return;
+				continue;
 			bool is_running = isRunning();
 			if (!is_running && !handled) {
 				handled = true;
@@ -138,7 +139,6 @@ class Timer : BaseComponent {
 				timing = true;
 				startnew(CoroutineFunc(keep_time));
 			}
-			yield();
 		}
 	}
 

--- a/src/Components/Timer.as
+++ b/src/Components/Timer.as
@@ -128,7 +128,6 @@ class Timer : BaseComponent {
 
 	void handler() override {
 		while (this.running) {
-			yield();
 
 			auto app = GetApp();
 #if TMNEXT || MP4
@@ -136,8 +135,10 @@ class Timer : BaseComponent {
 #elif TURBO
 			auto map = app.Challenge;
 #endif
-			if (map is null)
+			if (map is null) {
+				yield();
 				continue;
+			}
 			bool is_running = isRunning();
 			if (!is_running && !handled) {
 				handled = true;
@@ -146,6 +147,7 @@ class Timer : BaseComponent {
 				handled = false;
 				start_timing();
 			}
+			yield();
 		}
 	}
 

--- a/src/Components/Timer.as
+++ b/src/Components/Timer.as
@@ -4,7 +4,7 @@ class Timer : BaseComponent {
   private uint64 current_time = Time::Now;
   private uint64 session_offset = 0;
   private uint64 total_offset = 0;
-  private bool timing = true;
+  private bool timing = false;
 	bool same = false;
 
   private uint64 timer_start_idle = 0;
@@ -113,6 +113,7 @@ class Timer : BaseComponent {
 
 	void start() override {
 		running = true;
+		timing = true;
 		startnew(CoroutineFunc(handler));
 		startnew(CoroutineFunc(keep_time));
 	}

--- a/src/Components/Timer.as
+++ b/src/Components/Timer.as
@@ -20,7 +20,6 @@ class Timer : BaseComponent {
 
 	~Timer() {
 		this.timing = false;
-		this.running = false;
 	}
 
 	bool isRunning() {
@@ -105,7 +104,8 @@ class Timer : BaseComponent {
 		}
 	}
 
-	void stop() {
+	void stop() override {
+		running = false;
 		session_offset = session;
 		total_offset = total;
 		timing = false;

--- a/src/Components/Timer.as
+++ b/src/Components/Timer.as
@@ -95,11 +95,13 @@ class Timer : BaseComponent {
 #elif TURBO
 			auto map = app.Challenge;
 #endif
-			if (map !is null) {
-				current_time = Time::Now;
-				session = (current_time + session_offset) - start_time;
-				total = (current_time + total_offset) - start_time;
+			if (map is null) {
+				yield();
+				continue;
 			}
+			current_time = Time::Now;
+			session = (current_time + session_offset) - start_time;
+			total = (current_time + total_offset) - start_time;
 			yield();
 		}
 	}

--- a/src/Data/AbstractData.as
+++ b/src/Data/AbstractData.as
@@ -23,7 +23,7 @@ abstract class AbstractData {
 
 	void load() {}
 
-	void start() {
+	void start_components() {
 		timerComponent.start();
 		finishesComponent.start();
 		resetsComponent.start();
@@ -31,7 +31,7 @@ abstract class AbstractData {
 		medalsComponent.start();
 	}
 
-	void stop() {
+	void stop_components() {
 		timerComponent.stop();
 		finishesComponent.stop();
 		resetsComponent.stop();

--- a/src/Data/AbstractData.as
+++ b/src/Data/AbstractData.as
@@ -17,7 +17,6 @@ abstract class AbstractData {
 
 	AbstractData(const string &in id) {
 		mapUid = id;
-		start();
 	}
 
 	void save() {}

--- a/src/Data/AbstractData.as
+++ b/src/Data/AbstractData.as
@@ -31,6 +31,14 @@ abstract class AbstractData {
 		medalsComponent.start();
 	}
 
+	void stop() {
+		timerComponent.stop();
+		finishesComponent.stop();
+		resetsComponent.stop();
+		respawnsComponent.stop();
+		medalsComponent.stop();
+	}
+
 	void overwrite(AbstractData @other) {
 		time = other.time;
 		finishes = other.finishes;

--- a/src/Data/DataManager.as
+++ b/src/Data/DataManager.as
@@ -30,23 +30,29 @@ class DataManager {
 				continue;
 
 			// Map has changed.
-			print("saving and loading data");
-			auto_save_running = false;
-			localData.stop_components();
-			localData.save();
-			// cloudData.stop();
-			// cloudData.save();
+			if (this.mapId != "" && this.mapId != "Unassigned") {
+				print("Saving data & stopping coroutines for map \"" + this.mapId + "\"");
+				auto_save_running = false;
+				localData.stop_components();
+				localData.save();
+				// cloudData.stop();
+				// cloudData.save();
+			}
 
 			this.mapId = mapId_now;
 			localData = Files(this.mapId);
-			localData.load();
-			localData.start_components();
-			startnew(CoroutineFunc(auto_save));
-			// cloudData = Cloud(mapId);
-			// if (setting_data_source == data_source::Cloud) { // not implemented yet
-			//     cloudData.load();
-			//     DataConflict::handle_conflict(localData, cloudData);
-			// }
+
+			if (this.mapId != "" && this.mapId != "Unassigned") {
+				print("Loading data & starting coroutines for map \"" + this.mapId + "\"");
+				localData.load();
+				localData.start_components();
+				startnew(CoroutineFunc(auto_save));
+				// cloudData = Cloud(mapId);
+				// if (setting_data_source == data_source::Cloud) { // not implemented yet
+				//     cloudData.load();
+				//     DataConflict::handle_conflict(localData, cloudData);
+				// }
+			}
 		}
 	}
 

--- a/src/Data/DataManager.as
+++ b/src/Data/DataManager.as
@@ -32,9 +32,9 @@ class DataManager {
 			// Map has changed.
 			print("saving and loading data");
 			auto_save_running = false;
-			localData.timerComponent.stop();
+			localData.stop();
 			localData.save();
-			// cloudData.timerComponent.stop();
+			// cloudData.stop();
 			// cloudData.save();
 
 			localData = Files(this.mapId);

--- a/src/Data/DataManager.as
+++ b/src/Data/DataManager.as
@@ -13,21 +13,28 @@ class DataManager {
 	private void map_handler() {
 		auto app = GetApp();
 		while (true) {
-			yield();
-			if (app.Editor !is null)
+			if (app.Editor !is null) {
+				yield();
 				continue;
+			}
+			string mapId_now = "";
 #if TMNEXT
 			auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
-			string mapId_now = (playground is null || playground.Map is null) ? "" : playground.Map.IdName;
+			if (playground !is null && playground.Map !is null)
+				mapId_now = playground.Map.IdName;
 #elif MP4
 			auto rootmap = app.RootMap;
-			string mapId_now = (rootmap is null) ? "" : rootmap.IdName;
+			if (rootmap !is null)
+				mapId_now = rootmap.IdName;
 #elif TURBO
 			auto challenge = app.Challenge;
-			string mapId_now = (challenge is null) ? "" : challenge.IdName;
+			if (challenge !is null)
+				mapId_now = challenge.IdName;
 #endif
-			if (mapId_now == this.mapId)
+			if (mapId_now == this.mapId) {
+				yield();
 				continue;
+			}
 
 			// Map has changed.
 			if (this.mapId != "" && this.mapId != "Unassigned") {
@@ -53,6 +60,7 @@ class DataManager {
 				//     DataConflict::handle_conflict(localData, cloudData);
 				// }
 			}
+			yield();
 		}
 	}
 

--- a/src/Data/DataManager.as
+++ b/src/Data/DataManager.as
@@ -18,28 +18,29 @@ class DataManager {
 				continue;
 #if TMNEXT
 			auto playground = cast<CSmArenaClient>(app.CurrentPlayground);
-			this.mapId = (playground is null || playground.Map is null) ? "" : playground.Map.IdName;
+			string mapId_now = (playground is null || playground.Map is null) ? "" : playground.Map.IdName;
 #elif MP4
 			auto rootmap = app.RootMap;
-			this.mapId = (rootmap is null) ? "" : rootmap.IdName;
+			string mapId_now = (rootmap is null) ? "" : rootmap.IdName;
 #elif TURBO
 			auto challenge = app.Challenge;
-			this.mapId = (challenge is null) ? "" : challenge.IdName;
+			string mapId_now = (challenge is null) ? "" : challenge.IdName;
 #endif
-			if (this.mapId == localData.mapUid)
+			if (mapId_now == this.mapId)
 				continue;
 
 			// Map has changed.
 			print("saving and loading data");
 			auto_save_running = false;
-			localData.stop();
+			localData.stop_components();
 			localData.save();
 			// cloudData.stop();
 			// cloudData.save();
 
+			this.mapId = mapId_now;
 			localData = Files(this.mapId);
 			localData.load();
-			localData.start();
+			localData.start_components();
 			startnew(CoroutineFunc(auto_save));
 			// cloudData = Cloud(mapId);
 			// if (setting_data_source == data_source::Cloud) { // not implemented yet

--- a/src/Data/DataManager.as
+++ b/src/Data/DataManager.as
@@ -31,7 +31,10 @@ class DataManager {
 
 				localData = Files(this.mapId);
 				// cloudData = Cloud(mapId);
-				startnew(CoroutineFunc(load));
+				auto loading = startnew(CoroutineFunc(load));
+				while (loading.IsRunning())
+					yield();
+				localData.start();
 
 				startnew(CoroutineFunc(auto_save));
 			}

--- a/src/Medals/Medals.as
+++ b/src/Medals/Medals.as
@@ -140,6 +140,7 @@ class Medals : BaseComponent {
 
 	void handler() override {
 		while (running) {
+			yield();
 			if (first_run) {
 				first_run = false;
 #if TURBO
@@ -154,7 +155,7 @@ class Medals : BaseComponent {
 			auto map = app.Challenge;
 #endif
 			if (map is null)
-				return;
+				continue;
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -197,7 +198,6 @@ class Medals : BaseComponent {
 				}
 #endif
 			}
-			yield();
 		}
 	}
 

--- a/src/Medals/Medals.as
+++ b/src/Medals/Medals.as
@@ -140,7 +140,6 @@ class Medals : BaseComponent {
 
 	void handler() override {
 		while (running) {
-			yield();
 			if (first_run) {
 				first_run = false;
 #if TURBO
@@ -154,8 +153,10 @@ class Medals : BaseComponent {
 #elif TURBO
 			auto map = app.Challenge;
 #endif
-			if (map is null)
+			if (map is null) {
+				yield();
 				continue;
+			}
 			auto playground = app.CurrentPlayground;
 			auto network = cast<CTrackManiaNetwork>(app.Network);
 			if (playground !is null && playground.GameTerminals.Length > 0) {
@@ -198,6 +199,7 @@ class Medals : BaseComponent {
 				}
 #endif
 			}
+			yield();
 		}
 	}
 

--- a/src/Recap/RecapFiles.as
+++ b/src/Recap/RecapFiles.as
@@ -34,7 +34,5 @@ class RecapFiles : Files {
 		debug_print("Read finishes " + finishes + " resets " + resets + " time " + time + " respawns " + respawns + "\nmedals " + medals_string + "\nfrom " + file_location);
 	}
 
-	void start() override {} // don't need to start the handlers
-
 	int64 get_modified_time() { return IO::FileModifiedTime(file_location); }
 }


### PR DESCRIPTION
This resolves #69 

With these changes:

1. the component handlers only start when explicitely asked to
2. `map_handler` is given the full responsibility of starting/stopping handlers via calls to `AbstractData::start/stop_components()`
3. handlers are no longer started when entering the menu
4. `return` statements within handler loops have been removed (if somehow handlers were running in the menu, which should not occur anymore, they would simply do nothing, rather than exiting as they do now)

Of note, I initially broke `Timer` because it already had a `stop()` method and at first I hadn't understood what it was doing and that it wasn't related to `start()`. This method is now `stop_timing()`. But the issue should be fixed ; I believe I understood the timing code and I couldn't find any issues while testing.