### PR TITLE
Fix for 1.28.4

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -4,7 +4,7 @@ DataManager data;
 
 void Main() {
 #if TURBO
-	await(startnew(CoroutineFunc(TurboSTM::LoadSuperTimes)));
+	await(startnew(TurboSTM::LoadSuperTimes));
 #endif
 #if DEPENDENCY_NADEOSERVICES
 	NadeoServices::AddAudience("NadeoLiveServices");

--- a/src/Recap/RecapUI.as
+++ b/src/Recap/RecapUI.as
@@ -142,7 +142,7 @@ void RenderRecap() {
 			string text = "You have " + total_files + " files in your Grinding Stats data folder.\n" +
 						  "This will take a while depending on how many files you have.\n" +
 						  "It will lag/freeze the game while loading.";
-			vec2 textWidth = Draw::MeasureString(text);
+			vec2 textWidth = UI::MeasureString(text);
 			UI::SetCursorPos(vec2(windowWidth.x / 2 - textWidth.x / 2, windowWidth.y / 2 + 25));
 			UI::Text(text);
 			UI::SetCursorPos(vec2(windowWidth.x / 2 - 100, windowWidth.y / 2 - 25));


### PR DESCRIPTION
CoroutineFunc doesn't need to be called for normal functions, only for class methods. In older Angelscript versions it was a noop, but now it causes the following exception:

> Can't create delegate for types that do not support handles

Also fixes a deprecation for the Draw namespace

NOTE: This version should only be released for 1.28.4+. In previous versions it won't compile